### PR TITLE
4.0.0: Slightly improve Dashboard Map Performance

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/screen/WidgetMap.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/WidgetMap.java
@@ -76,6 +76,8 @@ public class WidgetMap extends ClickableWidgetExtension implements IGui {
 	public void render(GraphicsHolder graphicsHolder, int mouseX, int mouseY, float delta) {
 		final GuiDrawing guiDrawing = new GuiDrawing(graphicsHolder);
 		guiDrawing.beginDrawingRectangle();
+		// Background
+		guiDrawing.drawRectangle(getX2(), getY2(), getX2() + width, getY2() + height, ARGB_BLACK);
 
 		final IntIntImmutablePair topLeft = coordsToWorldPos(0, 0);
 		final IntIntImmutablePair bottomRight = coordsToWorldPos(width, height);
@@ -84,7 +86,10 @@ public class WidgetMap extends ClickableWidgetExtension implements IGui {
 			for (int j = topLeft.rightInt(); j <= bottomRight.rightInt(); j += increment) {
 				if (world != null) {
 					final int color = divideColorRGB(world.getBlockState(Init.newBlockPos(i, world.getTopY(HeightMapType.getMotionBlockingMapped(), i, j) - 1, j)).getBlock().getDefaultMapColor().getColorMapped(), 2);
-					drawRectangleFromWorldCoords(guiDrawing, i, j, i + increment, j + increment, ARGB_BLACK | color);
+					// Lazy render: Skip rendering block with no colors
+					if(color != 0) {
+						drawRectangleFromWorldCoords(guiDrawing, i, j, i + increment, j + increment, ARGB_BLACK | color);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Instead of rendering each block one by one, we first render a black background, then skip rendering blocks that are outside the chunk boundary / air block.

A bit of a band-aided solution, but should get us from ~5FPS to 30-ish FPS when zoomed-out, at least until someone took the effort to remake the map rendering in a performant way