### PR TITLE
Quick fix for the 1.20 loot tables

### DIFF
--- a/resources/common/normal/data/mtr/loot_tables/blocks/pids_1.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/pids_1.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/pids_2.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/pids_2.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/pids_3.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/pids_3.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/pids_4.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/pids_4.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/pids_single_arrival_1.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/pids_single_arrival_1.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_2_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_2_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_2_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_2_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_3_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_3_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_3_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_3_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_4_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_4_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_4_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_4_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_5_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_5_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_5_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_5_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_6_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_6_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_6_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_6_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_7_even.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_7_even.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",

--- a/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_7_odd.json
+++ b/resources/common/normal/data/mtr/loot_tables/blocks/railway_sign_7_odd.json
@@ -8,7 +8,7 @@
 					"type": "minecraft:item",
 					"conditions": [
 						{
-							"condition": "minecraft:alternative",
+							"condition": "minecraft:any_of",
 							"terms": [
 								{
 									"condition": "minecraft:block_state_property",


### PR DESCRIPTION
`minecraft:alternative` as a loot table condition was removed in 1.20. Because this wasn't fixed, railway signs and PIDs weren't dropping as items upon being broken. This fixes that.