### PR TITLE
Announcer Block - Delay

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/InitClient.java
+++ b/fabric/src/main/java/org/mtr/mod/InitClient.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.mapper.MinecraftClientHelper;
 import org.mtr.mapping.mapper.TextHelper;
 import org.mtr.mapping.registry.RegistryClient;
 import org.mtr.mod.block.BlockTactileMap;
+import org.mtr.mod.block.BlockTrainAnnouncer;
 import org.mtr.mod.client.CustomResourceLoader;
 import org.mtr.mod.client.DynamicTextureCache;
 import org.mtr.mod.client.IDrawing;
@@ -357,7 +358,7 @@ public final class InitClient {
 		});
 
 		REGISTRY_CLIENT.eventRegistryClient.registerStartClientTick(() -> {
-			final long currentMillis = System.currentTimeMillis();
+			final long currentMillis = getGameMillis();
 			final long millisElapsed = currentMillis - lastMillis;
 			lastMillis = currentMillis;
 			gameMillis += millisElapsed;
@@ -376,6 +377,14 @@ public final class InitClient {
 					MinecraftClientHelper.addEntity(new EntityRendering(new World(clientWorld.data)));
 				}
 			}
+
+			BlockTrainAnnouncer.DELAYED_TASKS.entrySet().removeIf(entry -> {
+				if (currentMillis >= entry.getKey()) {
+					entry.getValue().run();
+					return true;
+				}
+				return false;
+			});
 
 			// If player is moving, send a request every 0.5 seconds to the server to fetch any new nearby data
 			final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();

--- a/fabric/src/main/java/org/mtr/mod/InitClient.java
+++ b/fabric/src/main/java/org/mtr/mod/InitClient.java
@@ -358,7 +358,7 @@ public final class InitClient {
 		});
 
 		REGISTRY_CLIENT.eventRegistryClient.registerStartClientTick(() -> {
-			final long currentMillis = getGameMillis();
+			final long currentMillis = System.currentTimeMillis();
 			final long millisElapsed = currentMillis - lastMillis;
 			lastMillis = currentMillis;
 			gameMillis += millisElapsed;
@@ -379,7 +379,7 @@ public final class InitClient {
 			}
 
 			BlockTrainAnnouncer.DELAYED_TASKS.entrySet().removeIf(entry -> {
-				if (currentMillis >= entry.getKey()) {
+				if (gameMillis >= entry.getKey()) {
 					entry.getValue().run();
 					return true;
 				}

--- a/fabric/src/main/java/org/mtr/mod/block/BlockTrainAnnouncer.java
+++ b/fabric/src/main/java/org/mtr/mod/block/BlockTrainAnnouncer.java
@@ -6,11 +6,16 @@ import org.mtr.mapping.holder.BlockState;
 import org.mtr.mapping.holder.CompoundTag;
 import org.mtr.mapping.mapper.BlockEntityExtension;
 import org.mtr.mod.BlockEntityTypes;
+import org.mtr.mod.InitClient;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class BlockTrainAnnouncer extends BlockTrainSensorBase {
+
+	public static final Map<Long, Runnable> DELAYED_TASKS = new HashMap<>();
 
 	@Nonnull
 	@Override
@@ -22,10 +27,13 @@ public class BlockTrainAnnouncer extends BlockTrainSensorBase {
 
 		private String message = "";
 		private String soundId = "";
+		private String delay = "0";
 		private long lastAnnouncedMillis;
+		private long nextAnnouncementMillis;
 		private static final int ANNOUNCE_COOL_DOWN_MILLIS = 20000;
 		private static final String KEY_MESSAGE = "message";
 		private static final String KEY_SOUND_ID = "sound_id";
+		private static final String KEY_DELAY = "delay";
 
 		public BlockEntity(BlockPos pos, BlockState state) {
 			super(BlockEntityTypes.TRAIN_ANNOUNCER.get(), pos, state);
@@ -35,6 +43,7 @@ public class BlockTrainAnnouncer extends BlockTrainSensorBase {
 		public void readCompoundTag(CompoundTag compoundTag) {
 			message = compoundTag.getString(KEY_MESSAGE);
 			soundId = compoundTag.getString(KEY_SOUND_ID);
+			delay = compoundTag.getString(KEY_DELAY);
 			super.readCompoundTag(compoundTag);
 		}
 
@@ -42,12 +51,15 @@ public class BlockTrainAnnouncer extends BlockTrainSensorBase {
 		public void writeCompoundTag(CompoundTag compoundTag) {
 			compoundTag.putString(KEY_MESSAGE, message);
 			compoundTag.putString(KEY_SOUND_ID, soundId);
+			compoundTag.putString(KEY_DELAY, delay);
 			super.writeCompoundTag(compoundTag);
 		}
 
-		public void setData(LongAVLTreeSet filterRouteIds, boolean stoppedOnly, boolean movingOnly, String message, String soundId) {
+		public void setData(LongAVLTreeSet filterRouteIds, boolean stoppedOnly, boolean movingOnly, String message, String soundId, String delay) {
 			this.message = message;
 			this.soundId = soundId;
+			this.delay = delay;
+			this.nextAnnouncementMillis = System.currentTimeMillis() + getDelayInMillis(delay);
 			setData(filterRouteIds, stoppedOnly, movingOnly);
 		}
 
@@ -59,17 +71,35 @@ public class BlockTrainAnnouncer extends BlockTrainSensorBase {
 			return soundId;
 		}
 
-		public void announce(Consumer<String> messageConsumer, Consumer<String> soundIdConsumer) {
-			final long currentMillis = System.currentTimeMillis();
-			if (currentMillis - lastAnnouncedMillis >= ANNOUNCE_COOL_DOWN_MILLIS) {
-				if (!message.isEmpty()) {
-					messageConsumer.accept(message);
-				}
-				if (!soundId.isEmpty()) {
-					soundIdConsumer.accept(soundId);
-				}
-				lastAnnouncedMillis = System.currentTimeMillis();
+		public String getDelay() {
+			return delay;
+		}
+
+		private long getDelayInMillis(String delayStr) {
+			try {
+				int delayInt = Integer.parseInt(delayStr);
+				return delayInt * 1000L;
+			} catch (NumberFormatException e) {
+				return 0;
 			}
+		}
+
+		public void announce(Consumer<String> messageConsumer, Consumer<String> soundIdConsumer, double delayInSec) {
+			long gameMillisNow = InitClient.getGameMillis();
+			long delayMillis = (long) (delayInSec * 1000);
+			DELAYED_TASKS.put(gameMillisNow + delayMillis, () -> {
+				final long currentMillis = System.currentTimeMillis();
+				if (currentMillis >= nextAnnouncementMillis) {
+					if (!message.isEmpty()) {
+						messageConsumer.accept(message);
+					}
+					if (!soundId.isEmpty()) {
+						soundIdConsumer.accept(soundId);
+					}
+					lastAnnouncedMillis = currentMillis;
+					nextAnnouncementMillis = currentMillis + getDelayInMillis(delay);
+				}
+			});
 		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/data/VehicleExtension.java
+++ b/fabric/src/main/java/org/mtr/mod/data/VehicleExtension.java
@@ -14,10 +14,7 @@ import org.mtr.mapping.mapper.TextHelper;
 import org.mtr.mod.Init;
 import org.mtr.mod.InitClient;
 import org.mtr.mod.Items;
-import org.mtr.mod.block.BlockTrainAnnouncer;
-import org.mtr.mod.block.BlockTrainRedstoneSensor;
-import org.mtr.mod.block.BlockTrainSensorBase;
-import org.mtr.mod.block.IBlock;
+import org.mtr.mod.block.*;
 import org.mtr.mod.client.IDrawing;
 import org.mtr.mod.client.MinecraftClientData;
 import org.mtr.mod.client.VehicleRidingMovement;
@@ -26,6 +23,8 @@ import org.mtr.mod.packet.PacketTurnOnBlockEntity;
 import org.mtr.mod.resource.VehicleResource;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class VehicleExtension extends Vehicle implements Utilities {
 
@@ -207,7 +206,8 @@ public class VehicleExtension extends Vehicle implements Utilities {
 							if (blockEntity != null && blockEntity.data instanceof BlockTrainAnnouncer.BlockEntity) {
 								((BlockTrainAnnouncer.BlockEntity) blockEntity.data).announce(
 										message -> IDrawing.narrateOrAnnounce(message, ObjectArrayList.of(TextHelper.literal(message))),
-										soundId -> clientPlayerEntity.playSound(SoundHelper.createSoundEvent(new Identifier(soundId)), 1000, 1)
+										soundId -> clientPlayerEntity.playSound(SoundHelper.createSoundEvent(new Identifier(soundId)), 1000, 1),
+										Double.parseDouble(((BlockTrainAnnouncer.BlockEntity) blockEntity.data).getDelay())
 								);
 							}
 						}

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainAnnouncerConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainAnnouncerConfig.java
@@ -13,17 +13,20 @@ public class PacketUpdateTrainAnnouncerConfig extends PacketUpdateTrainSensorCon
 
 	private final String message;
 	private final String soundId;
+	private final String delay;
 
 	public PacketUpdateTrainAnnouncerConfig(PacketBufferReceiver packetBufferReceiver) {
 		super(packetBufferReceiver);
 		message = packetBufferReceiver.readString();
 		soundId = packetBufferReceiver.readString();
+		delay = packetBufferReceiver.readString();
 	}
 
-	public PacketUpdateTrainAnnouncerConfig(BlockPos blockPos, LongAVLTreeSet filterRouteIds, boolean stoppedOnly, boolean movingOnly, String message, String soundId) {
+	public PacketUpdateTrainAnnouncerConfig(BlockPos blockPos, LongAVLTreeSet filterRouteIds, boolean stoppedOnly, boolean movingOnly, String message, String soundId, String delay) {
 		super(blockPos, filterRouteIds, stoppedOnly, movingOnly);
 		this.message = message;
 		this.soundId = soundId;
+		this.delay = delay;
 	}
 
 	@Override
@@ -31,13 +34,14 @@ public class PacketUpdateTrainAnnouncerConfig extends PacketUpdateTrainSensorCon
 		super.write(packetBufferSender);
 		packetBufferSender.writeString(message);
 		packetBufferSender.writeString(soundId);
+		packetBufferSender.writeString(delay);
 	}
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockTrainAnnouncer.BlockEntity) {
-			((BlockTrainAnnouncer.BlockEntity) entity.data).setData(filterRouteIds, stoppedOnly, movingOnly, message, soundId);
+			((BlockTrainAnnouncer.BlockEntity) entity.data).setData(filterRouteIds, stoppedOnly, movingOnly, message, soundId, delay);
 		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/screen/TrainAnnouncerScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/TrainAnnouncerScreen.java
@@ -19,23 +19,28 @@ public class TrainAnnouncerScreen extends TrainSensorScreenBase {
 
 	private final String initialMessage;
 	private final String initialSoundId;
+	private final String initialDelay;
 	private final DashboardList availableSoundsList;
 
 	private static final int MAX_MESSAGE_LENGTH = 256;
+	private static final int MAX_DELAY_LENGTH = 5;
 
 	public TrainAnnouncerScreen(BlockPos pos, BlockTrainAnnouncer.BlockEntity blockEntity) {
 		super(pos, true,
 				new ObjectObjectImmutablePair<>(new TextFieldWidgetExtension(0, 0, 0, SQUARE_SIZE, MAX_MESSAGE_LENGTH, TextCase.DEFAULT, null, null), TranslationProvider.GUI_MTR_ANNOUNCEMENT_MESSAGE.getMutableText()),
-				new ObjectObjectImmutablePair<>(new TextFieldWidgetExtension(0, 0, 0, SQUARE_SIZE, MAX_MESSAGE_LENGTH, TextCase.DEFAULT, null, null), TranslationProvider.GUI_MTR_SOUND_FILE.getMutableText())
+				new ObjectObjectImmutablePair<>(new TextFieldWidgetExtension(0, 0, 0, SQUARE_SIZE, MAX_MESSAGE_LENGTH, TextCase.DEFAULT, null, null), TranslationProvider.GUI_MTR_SOUND_FILE.getMutableText()),
+				new ObjectObjectImmutablePair<>(new TextFieldWidgetExtension(0, 0, 0, SQUARE_SIZE, MAX_DELAY_LENGTH, TextCase.DEFAULT, null, null), TranslationProvider.GUI_MTR_DELAY.getMutableText())
 		);
 
 		final ClientWorld clientWorld = MinecraftClient.getInstance().getWorldMapped();
 		if (clientWorld != null) {
 			initialMessage = blockEntity.getMessage();
 			initialSoundId = blockEntity.getSoundId();
+			initialDelay = blockEntity.getDelay();
 		} else {
 			initialMessage = "";
 			initialSoundId = "";
+			initialDelay = "0";
 		}
 
 		availableSoundsList = new DashboardList((data, color) -> {
@@ -60,11 +65,12 @@ public class TrainAnnouncerScreen extends TrainSensorScreenBase {
 		super.init2();
 		textFields[0].setText2(initialMessage);
 		textFields[1].setText2(initialSoundId);
+		textFields[2].setText2(initialDelay);
 
 		setListVisibility(false);
 		availableSoundsList.y = SQUARE_SIZE * 2 + TEXT_HEIGHT + TEXT_PADDING + TEXT_FIELD_PADDING;
 		availableSoundsList.height = height - availableSoundsList.y - SQUARE_SIZE;
-		availableSoundsList.width = width / 2 - SQUARE_SIZE;
+		availableSoundsList.width = width / 3 - SQUARE_SIZE;
 		availableSoundsList.init(this::addChild);
 	}
 
@@ -108,10 +114,10 @@ public class TrainAnnouncerScreen extends TrainSensorScreenBase {
 
 	@Override
 	protected void sendUpdate(BlockPos blockPos, LongAVLTreeSet filterRouteIds, boolean stoppedOnly, boolean movingOnly) {
-		InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketUpdateTrainAnnouncerConfig(blockPos, filterRouteIds, stoppedOnly, movingOnly, textFields[0].getText2(), textFields[1].getText2()));
+		InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketUpdateTrainAnnouncerConfig(blockPos, filterRouteIds, stoppedOnly, movingOnly, textFields[0].getText2(), textFields[1].getText2(), textFields[2].getText2()));
 	}
 
 	private void setListVisibility(boolean visible) {
-		availableSoundsList.x = visible ? width / 2 : width;
+		availableSoundsList.x = visible ? width / 3 : width;
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/screen/TrainSensorScreenBase.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/TrainSensorScreenBase.java
@@ -112,7 +112,7 @@ public abstract class TrainSensorScreenBase extends ScreenExtension implements I
 		try {
 			renderBackground(graphicsHolder);
 			for (int i = 0; i < textFieldCount; i++) {
-				graphicsHolder.drawText(textFieldLabels[i], SQUARE_SIZE + (width / 2 - SQUARE_SIZE) * i, SQUARE_SIZE, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
+				graphicsHolder.drawText(textFieldLabels[i], SQUARE_SIZE + i * (textFields[i].getWidth2() + TEXT_FIELD_PADDING), SQUARE_SIZE, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			}
 			graphicsHolder.drawText(TranslationProvider.GUI_MTR_FILTERED_ROUTES.getMutableText(filterRouteIds.size()), SQUARE_SIZE, yStart + TEXT_PADDING, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText((filterRouteIds.isEmpty() ? TranslationProvider.GUI_MTR_FILTERED_ROUTES_EMPTY : TranslationProvider.GUI_MTR_FILTERED_ROUTES_CONDITION).getMutableText(), SQUARE_SIZE, yStart + SQUARE_SIZE + TEXT_PADDING, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());

--- a/fabric/src/main/resources/assets/mtr/lang/en_us.json
+++ b/fabric/src/main/resources/assets/mtr/lang/en_us.json
@@ -200,6 +200,7 @@
 	"gui.mtr.custom_resources_train_barrier_id": "Train Barrier ID",
 	"gui.mtr.days": "%s day(s)",
 	"gui.mtr.deceleration": "Vehicle Deceleration",
+	"gui.mtr.delay": "Delay (in seconds)",
 	"gui.mtr.delayed_vehicle_reduce_dwell_time_percentage": "Reduce Dwell Time When Delayed",
 	"gui.mtr.delayed_vehicle_speed_increase_percentage": "Increase Speed When Delayed",
 	"gui.mtr.delete_confirmation": "Are you sure you want to delete %s?",


### PR DESCRIPTION
You can now configure a delay for when text and sound announcements should be triggered. Additionally, I had to modify the previous calculation for the `textFieldLabel` X position. The previous implementation had issues with more than 2 text fields, it should now be fine.