### PR TITLE
Fix: Properly stop Minecraft Server when TSC not responding

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/Init.java
+++ b/fabric/src/main/java/org/mtr/mod/Init.java
@@ -184,14 +184,8 @@ public final class Init implements Utilities {
 					);
 				} else {
 					Main.LOGGER.error("Transport Simulation Core not responding; stopping Minecraft server!");
-					if (main != null) {
-						main.stop();
-					}
-					if (webserver != null) {
-						webserver.stop();
-					}
-					Main.LOGGER.error("Shutting down all threads");
-					System.exit(0);
+					minecraftServer.stop(false);
+					canSendWorldTimeUpdate = true; // In singleplayer, this gives the player opportunity to re-enter world.
 				}
 			};
 		});

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This gracefully shuts down the Minecraft Server, as in some cases the server would not get shut down. (Forge doesn't like System.exit AFAIK)
It also allows re-entering the world in singleplayer after the server has shut down.