### PR TITLE
Fixes & Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
 			exclude(dependency("org.mtr:Minecraft-Mappings-fabric-${minecraftVersion}:.*"))
 			exclude(dependency("org.mtr:Minecraft-Mappings-forge-${minecraftVersion}:.*"))
 		}
-		relocate "com.logisticscraft", "org.mtr.libraries.com.logisticscraft"
+			relocate "com.logisticscraft", "org.mtr.libraries.com.logisticscraft"
 		relocate "de.javagl", "org.mtr.libraries.de.javagl"
 		relocate "io.nayuki", "org.mtr.libraries.io.nayuki"
 	}

--- a/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
+++ b/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
@@ -117,11 +117,14 @@ public class BuildTools {
 	}
 
 	public void copyFontDefinition() throws IOException {
+		String legacyFont = "legacy_unicode\",\"sizes\": \"minecraft:font/glyph_sizes.bin\",\"template\": \"minecraft:font/unicode_page_%s.png";
+		String modernFont = "reference\", \"id\": \"minecraft:include/space\"}, {\"type\": \"reference\", \"id\": \"minecraft:include/default\"}, {  \"type\": \"reference\", \"id\": \"minecraft:include/unifont";
+
 		FileUtils.write(
 				path.resolve("src/main/resources/assets/mtr/font/mtr.json").toFile(),
 				FileUtils.readFileToString(path.resolve("src/main/font_template.json").toFile(), StandardCharsets.UTF_8).replace(
 						"@type@",
-						majorVersion >= 20 ? "reference\",\"id\":\"minecraft:include/default" : "legacy_unicode\",\"sizes\":\"minecraft:font/glyph_sizes.bin\",\"template\":\"minecraft:font/unicode_page_%s.png"
+						majorVersion >= 20 ? modernFont : legacyFont
 				),
 				StandardCharsets.UTF_8
 		);

--- a/fabric/src/main/font_template.json
+++ b/fabric/src/main/font_template.json
@@ -13,8 +13,6 @@
 			"size": 12.0,
 			"oversample": 16.0
 		},
-		{
-			"type": "@type@"
-		}
+		{ "type": "@type@" }
 	]
 }

--- a/fabric/src/main/java/org/mtr/mod/Init.java
+++ b/fabric/src/main/java/org/mtr/mod/Init.java
@@ -261,8 +261,8 @@ public final class Init implements Utilities {
 		return new BlockPos(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z));
 	}
 
-	public static boolean isChunkLoaded(World world, ChunkManager chunkManager, BlockPos blockPos) {
-		return chunkManager.getWorldChunk(blockPos.getX() / 16, blockPos.getZ() / 16) != null && world.isRegionLoaded(blockPos, blockPos);
+	public static boolean isChunkLoaded(World world, BlockPos blockPos) {
+		return world.getChunkManager().getWorldChunk(blockPos.getX() / 16, blockPos.getZ() / 16) != null && world.isRegionLoaded(blockPos, blockPos);
 	}
 
 	public static String getWorldId(World world) {

--- a/fabric/src/main/java/org/mtr/mod/InitClient.java
+++ b/fabric/src/main/java/org/mtr/mod/InitClient.java
@@ -45,6 +45,7 @@ public final class InitClient {
 	private static long lastPlayedTrainSoundsMillis = 0;
 	private static long lastUpdatePacketMillis = 0;
 	private static Runnable movePlayer;
+	private static ClientWorld lastClientWorld;
 
 	public static final RegistryClient REGISTRY_CLIENT = new RegistryClient(Init.REGISTRY);
 	public static final int MILLIS_PER_SPEED_SOUND = 200;
@@ -379,6 +380,11 @@ public final class InitClient {
 				if (shouldCreateEntity[0]) {
 					MinecraftClientHelper.addEntity(new EntityRendering(new World(clientWorld.data)));
 				}
+
+				if(lastClientWorld == null || !lastClientWorld.equals(clientWorld)) { // World or Dimension changed
+					lastClientWorld = clientWorld;
+					MinecraftClientData.reset();
+				}
 			}
 
 			BlockTrainAnnouncer.processQueue();
@@ -392,6 +398,8 @@ public final class InitClient {
 				lastUpdatePacketMillis = -1;
 			}
 		});
+
+
 
 		REGISTRY_CLIENT.eventRegistryClient.registerEndClientTick(() -> {
 			if (movePlayer != null) {

--- a/fabric/src/main/java/org/mtr/mod/block/BlockEyeCandy.java
+++ b/fabric/src/main/java/org/mtr/mod/block/BlockEyeCandy.java
@@ -24,6 +24,11 @@ public class BlockEyeCandy extends BlockExtension implements DirectionHelper, Bl
 	}
 
 	@Override
+	public VoxelShape getCollisionShape2(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+		return VoxelShapes.empty();
+	}
+
+	@Override
 	public void addBlockProperties(List<HolderBase<?>> properties) {
 		properties.add(FACING);
 	}

--- a/fabric/src/main/java/org/mtr/mod/block/BlockPSDAPGDoorBase.java
+++ b/fabric/src/main/java/org/mtr/mod/block/BlockPSDAPGDoorBase.java
@@ -65,7 +65,7 @@ public abstract class BlockPSDAPGDoorBase extends BlockPSDAPGBase implements Blo
 	public VoxelShape getCollisionShape2(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
 		// The serverside collision shape is always empty, and the clientside collision shape is determined by the vehicle door positions the client sees
 		final BlockEntity entity = world.getBlockEntity(pos);
-		if (entity != null && entity.data instanceof BlockEntityBase && entity.getWorld() != null && entity.getWorld().isClient() && ((BlockEntityBase) entity.data).doorValue == 0) {
+		if (entity != null && entity.data instanceof BlockEntityBase && entity.getWorld() != null && entity.getWorld().isClient() && ((BlockEntityBase) entity.data).getDoorValue() == 0) {
 			return super.getCollisionShape2(state, world, pos, context);
 		} else {
 			return VoxelShapes.empty();

--- a/fabric/src/main/java/org/mtr/mod/block/BlockPSDAPGDoorBase.java
+++ b/fabric/src/main/java/org/mtr/mod/block/BlockPSDAPGDoorBase.java
@@ -137,6 +137,9 @@ public abstract class BlockPSDAPGDoorBase extends BlockPSDAPGBase implements Blo
 		}
 
 		private boolean receivedRedstonePower(World world, BlockPos pos, BlockState state) {
+			final boolean doorUnlocked = IBlock.getStatePropertySafe(state, UNLOCKED);
+			if(!doorUnlocked) return false;
+
 			final DoubleBlockHalf half = IBlock.getStatePropertySafe(state, HALF);
 			final Direction facing = IBlock.getStatePropertySafe(state, FACING);
 			final EnumSide side = IBlock.getStatePropertySafe(state, SIDE);

--- a/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
@@ -53,7 +53,7 @@ public class CustomResourceLoader {
 		RESOURCE_CACHE.clear();
 		VEHICLES.forEach((transportMode, vehicleResources) -> vehicleResources.clear());
 		VEHICLES_CACHE.forEach((transportMode, vehicleResourcesCache) -> vehicleResourcesCache.clear());
-		SIGNS.clear();
+		SIGNS.clear();	
 		SIGNS_CACHE.clear();
 		RAILS.clear();
 		RAILS_CACHE.clear();

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketTurnOnBlockEntity.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketTurnOnBlockEntity.java
@@ -5,6 +5,7 @@ import org.mtr.mapping.mapper.BlockExtension;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockTrainPoweredSensorBase;
 import org.mtr.mod.block.IBlock;
 
@@ -28,6 +29,8 @@ public final class PacketTurnOnBlockEntity extends PacketHandler {
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
 		final World world = new World(serverPlayerEntity.getServerWorld().data);
+		if(!Init.isChunkLoaded(world, blockPos)) return;
+
 		final BlockState blockState = world.getBlockState(blockPos);
 		final Block block = blockState.getBlock();
 		if (block.data instanceof BlockTrainPoweredSensorBase && (IBlock.getStatePropertySafe(blockState, BlockTrainPoweredSensorBase.POWERED) <= 1 || !BlockExtension.hasScheduledTick(world, blockPos, block))) {

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateEyeCandyConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateEyeCandyConfig.java
@@ -7,6 +7,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockEyeCandy;
 
 import javax.annotation.Nullable;
@@ -58,6 +59,8 @@ public final class PacketUpdateEyeCandyConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+		
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockEyeCandy.BlockEntity) {
 			((BlockEyeCandy.BlockEntity) entity.data).setData(modelId, translateX, translateY, translateZ, rotateX, rotateY, rotateZ, fullLight);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateLiftTrackFloorConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateLiftTrackFloorConfig.java
@@ -7,6 +7,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockLiftTrackFloor;
 
 public final class PacketUpdateLiftTrackFloorConfig extends PacketHandler {
@@ -40,6 +41,8 @@ public final class PacketUpdateLiftTrackFloorConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockLiftTrackFloor.BlockEntity) {
 			((BlockLiftTrackFloor.BlockEntity) entity.data).setData(floorNumber, floorDescription, shouldDing);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdatePIDSConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdatePIDSConfig.java
@@ -8,6 +8,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockPIDSBase;
 
 public final class PacketUpdatePIDSConfig extends PacketHandler {
@@ -69,6 +70,8 @@ public final class PacketUpdatePIDSConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockPIDSBase.BlockEntityBase) {
 			((BlockPIDSBase.BlockEntityBase) entity.data).setData(messages, hideArrivalArray, platformIds, displayPage);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateRailwaySignConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateRailwaySignConfig.java
@@ -8,6 +8,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockRailwaySign;
 import org.mtr.mod.block.BlockRouteSignBase;
 
@@ -51,6 +52,8 @@ public final class PacketUpdateRailwaySignConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null) {
 			if (entity.data instanceof BlockRailwaySign.BlockEntity) {

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateSignalConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateSignalConfig.java
@@ -8,6 +8,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockSignalBase;
 
 public final class PacketUpdateSignalConfig extends PacketHandler {
@@ -42,6 +43,8 @@ public final class PacketUpdateSignalConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockSignalBase.BlockEntityBase) {
 			((BlockSignalBase.BlockEntityBase) entity.data).setData(signalColors, isBackSide);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainAnnouncerConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainAnnouncerConfig.java
@@ -7,6 +7,7 @@ import org.mtr.mapping.holder.MinecraftServer;
 import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockTrainAnnouncer;
 
 public class PacketUpdateTrainAnnouncerConfig extends PacketUpdateTrainSensorConfig {
@@ -39,6 +40,8 @@ public class PacketUpdateTrainAnnouncerConfig extends PacketUpdateTrainSensorCon
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockTrainAnnouncer.BlockEntity) {
 			((BlockTrainAnnouncer.BlockEntity) entity.data).setData(filterRouteIds, stoppedOnly, movingOnly, message, soundId, delay);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainScheduleSensorConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainScheduleSensorConfig.java
@@ -7,6 +7,7 @@ import org.mtr.mapping.holder.MinecraftServer;
 import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockTrainScheduleSensor;
 
 public class PacketUpdateTrainScheduleSensorConfig extends PacketUpdateTrainSensorConfig {
@@ -35,6 +36,8 @@ public class PacketUpdateTrainScheduleSensorConfig extends PacketUpdateTrainSens
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockTrainScheduleSensor.BlockEntity) {
 			((BlockTrainScheduleSensor.BlockEntity) entity.data).setData(filterRouteIds, stoppedOnly, movingOnly, seconds, realtimeOnly);

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainSensorConfig.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateTrainSensorConfig.java
@@ -8,6 +8,7 @@ import org.mtr.mapping.holder.ServerPlayerEntity;
 import org.mtr.mapping.registry.PacketHandler;
 import org.mtr.mapping.tool.PacketBufferReceiver;
 import org.mtr.mapping.tool.PacketBufferSender;
+import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockTrainSensorBase;
 
 public class PacketUpdateTrainSensorConfig extends PacketHandler {
@@ -46,6 +47,8 @@ public class PacketUpdateTrainSensorConfig extends PacketHandler {
 
 	@Override
 	public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+		if(!Init.isChunkLoaded(serverPlayerEntity.getEntityWorld(), blockPos)) return;
+
 		final BlockEntity entity = serverPlayerEntity.getEntityWorld().getBlockEntity(blockPos);
 		if (entity != null && entity.data instanceof BlockTrainSensorBase.BlockEntityBase) {
 			((BlockTrainSensorBase.BlockEntityBase) entity.data).setData(filterRouteIds, stoppedOnly, movingOnly);

--- a/fabric/src/main/java/org/mtr/mod/render/MainRenderer.java
+++ b/fabric/src/main/java/org/mtr/mod/render/MainRenderer.java
@@ -56,7 +56,7 @@ public class MainRenderer extends EntityRenderer<EntityRendering> implements IGu
 
 	@Override
 	public void render(EntityRendering entityRendering, float yaw, float tickDelta, GraphicsHolder graphicsHolder, int i) {
-		render(graphicsHolder, entityRendering.getCameraPosVec2(MinecraftClient.getInstance().getTickDelta()));
+		render(graphicsHolder, entityRendering.getCameraPosVec2(tickDelta));
 	}
 
 	@Override

--- a/fabric/src/main/java/org/mtr/mod/render/RenderLiftButtons.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderLiftButtons.java
@@ -89,7 +89,7 @@ public class RenderLiftButtons extends BlockEntityRenderer<BlockLiftButtons.Bloc
 		final HitResult hitResult = MinecraftClient.getInstance().getCrosshairTargetMapped();
 		final boolean lookingAtTopHalf;
 		final boolean lookingAtBottomHalf;
-		if (hitResult == null || !IBlock.getStatePropertySafe(blockState, BlockLiftButtons.UNLOCKED)) {
+		if (clientPlayerEntity.isSpectator() || hitResult == null || !IBlock.getStatePropertySafe(blockState, BlockLiftButtons.UNLOCKED)) {
 			lookingAtTopHalf = false;
 			lookingAtBottomHalf = false;
 		} else {

--- a/fabric/src/main/java/org/mtr/mod/screen/EditStationScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/EditStationScreen.java
@@ -255,6 +255,7 @@ public class EditStationScreen extends EditNameColorScreenBase<Station> {
 	}
 
 	private void onDeleteExitParent(DashboardListItem dashboardListItem, int index) {
+		data.getExits().remove(index);
 		changeEditingExit(null, -1);
 	}
 


### PR DESCRIPTION
- Fix jittery rendering when game is paused.
- Fix Redstone powered PSD/APG not changing the collision
- Fix Redstone powered PSD/APG not accounting for when the door is locked
- Fix not being able to delete exit parent
- Fix train staying when switched to other dimension (#936 )
- Fix NTE Decoration Block having collision
- Fix potential packet chunk-loading exploit, being able to force server to load chunks.
- Fix unsupported unicode characters getting displayed as square when using MC Font rendering + MTR Font
- Do not highlight lift button in spectator (QOL, spectator should not appear to interact with the world)