### PR TITLE
Station color blocks fix

### DIFF
--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine.json
@@ -1,6 +1,6 @@
 {
 	"parent": "block/leaves",
 	"textures": {
-		"all": "mtr:block/station_color_dark_prismarine"
+		"all": "minecraft:block/dark_prismarine"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine_slab_bottom.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine_slab_bottom.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_bottom_base",
 	"textures": {
-		"particle": "mtr:block/station_color_dark_prismarine",
-		"texture": "mtr:block/station_color_dark_prismarine"
+		"particle": "minecraft:block/dark_prismarine",
+		"texture": "minecraft:block/dark_prismarine"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine_slab_top.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_dark_prismarine_slab_top.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_top_base",
 	"textures": {
-		"particle": "mtr:block/station_color_dark_prismarine",
-		"texture": "mtr:block/station_color_dark_prismarine"
+		"particle": "minecraft:block/dark_prismarine",
+		"texture": "minecraft:block/dark_prismarine"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_planks.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_planks.json
@@ -1,6 +1,6 @@
 {
 	"parent": "block/leaves",
 	"textures": {
-		"all": "mtr:block/station_color_planks"
+		"all": "block/oak_planks"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_planks_slab_bottom.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_planks_slab_bottom.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_bottom_base",
 	"textures": {
-		"particle": "mtr:block/station_color_planks",
-		"texture": "mtr:block/station_color_planks"
+		"particle": "block/oak_planks",
+		"texture": "block/oak_planks"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_planks_slab_top.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_planks_slab_top.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_top_base",
 	"textures": {
-		"particle": "mtr:block/station_color_planks",
-		"texture": "mtr:block/station_color_planks"
+		"particle": "block/oak_planks",
+		"texture": "block/oak_planks"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block.json
@@ -1,6 +1,6 @@
 {
 	"parent": "block/leaves",
 	"textures": {
-		"all": "mtr:block/station_color_purpur_block"
+		"all": "block/purpur_block"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block_slab_bottom.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block_slab_bottom.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_bottom_base",
 	"textures": {
-		"particle": "mtr:block/station_color_purpur_block",
-		"texture": "mtr:block/station_color_purpur_block"
+		"particle": "block/purpur_block",
+		"texture": "block/purpur_block"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block_slab_top.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_block_slab_top.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_top_base",
 	"textures": {
-		"particle": "mtr:block/station_color_purpur_block",
-		"texture": "mtr:block/station_color_purpur_block"
+		"particle": "block/purpur_block",
+		"texture": "block/purpur_block"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/leaves_column",
 	"textures": {
-		"end": "mtr:block/station_color_purpur_pillar_top",
-		"side": "mtr:block/station_color_purpur_pillar"
+		"end": "block/purpur_pillar_top",
+		"side": "block/purpur_pillar"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar_slab_bottom.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar_slab_bottom.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_bottom_pillar_base",
 	"textures": {
-		"end": "mtr:block/station_color_purpur_pillar_top",
-		"side": "mtr:block/station_color_purpur_pillar"
+		"end": "block/purpur_pillar_top",
+		"side": "block/purpur_pillar"
 	}
 }

--- a/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar_slab_top.json
+++ b/fabric/src/main/resources/assets/mtr/models/block/station_color_purpur_pillar_slab_top.json
@@ -1,7 +1,7 @@
 {
 	"parent": "mtr:block/station_color_slab_top_pillar_base",
 	"textures": {
-		"end": "mtr:block/station_color_purpur_pillar_top",
-		"side": "mtr:block/station_color_purpur_pillar"
+		"end": "block/purpur_pillar_top",
+		"side": "block/purpur_pillar"
 	}
 }


### PR DESCRIPTION
Changed some station color blocks' model files to use "minecraft:" as opposed to "mtr:" textures, thereby allowing for functionality with non-vanilla texture packs. 