### PR TITLE
Optimize randomString method using System.nanoTime()

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/Init.java
+++ b/fabric/src/main/java/org/mtr/mod/Init.java
@@ -352,7 +352,7 @@ public final class Init implements Utilities {
 	}
 
 	public static String randomString() {
-		return Integer.toHexString(new Random().nextInt());
+		return Long.toHexString(System.nanoTime());
 	}
 
 	private static void depotOperationFromCommand(CommandBuilder<?> commandBuilder, DepotOperation depotOperation) {


### PR DESCRIPTION
https://github.com/Minecraft-Transit-Railway/Minecraft-Transit-Railway/blob/71120016f9b0e439f071f466b9403dcc798776c7/fabric/src/main/java/org/mtr/mod/Init.java#L354-L356

Since the random strings are hex random numbers, there is a tiny chance that two of them will be equal and cause wrong textures to be rendered.

This pull request replaced `new Random().nextInt()` with `System.nanoTime()`, therefore, each texture will be given a unique id when generated. Though nano time is not timestamp, it begins when JVM launches. I believe this solution can fix duplicate IDs.

![QQ图片20250118143856](https://github.com/user-attachments/assets/ef95aedb-d87d-4e17-9db3-654e0307dc0d)
An example of two textures being allocated the same ID - the old one is being replaced.