### PR TITLE
Create BlockBreakMixin.java

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/block/BlockBreakMixin.java
+++ b/fabric/src/main/java/org/mtr/mod/block/BlockBreakMixin.java
@@ -1,0 +1,29 @@
+package org.mtr.mod.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.mtr.mod.blocks.BlockMTR;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerInteractionManager.class)
+public class BlockBreakMixin {
+    
+    @Inject(method = "tryBreakBlock", at = @At("HEAD"), cancellable = true)
+    private void preventMtrBlockBreak(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        ServerPlayerInteractionManager manager = (ServerPlayerInteractionManager) (Object) this;
+        ServerPlayerEntity player = manager.player;
+        World world = player.getWorld();
+        BlockState state = world.getBlockState(pos);
+        
+        // Prevent breaking if block is an MTR-related block and player is NOT in creative mode
+        if (state.getBlock() instanceof BlockMTR && !player.isCreative()) {
+            cir.setReturnValue(false);  // Cancel block breaking
+        }
+    }
+}


### PR DESCRIPTION
This method ensures that all MTR-related blocks cannot be broken in survival mode.