### PR TITLE
Add option for vehicle oscillation amount

### DIFF
--- a/buildSrc/src/main/resources/schema/config/client.json
+++ b/buildSrc/src/main/resources/schema/config/client.json
@@ -19,6 +19,10 @@
 		"languageDisplay": {
 			"$ref": "LanguageDisplay"
 		},
+		"vehicleOscillationMultiplier": {
+			"type": "number",
+			"default": 1.0
+		},
 		"dynamicTextureResolution": {
 			"type": "integer",
 			"default": 2

--- a/fabric/src/main/java/org/mtr/mod/config/Client.java
+++ b/fabric/src/main/java/org/mtr/mod/config/Client.java
@@ -8,6 +8,7 @@ import org.mtr.mod.generated.config.ClientSchema;
 public final class Client extends ClientSchema {
 
 	public static final int DYNAMIC_RESOLUTION_COUNT = 8;
+	public static final int TRAIN_OSCILLATION_COUNT = 15;
 
 	public Client(ReaderBase readerBase) {
 		super(readerBase);
@@ -32,6 +33,10 @@ public final class Client extends ClientSchema {
 
 	public int getDynamicTextureResolution() {
 		return (int) dynamicTextureResolution;
+	}
+
+	public double getVehicleOscillationMultiplier() {
+		return vehicleOscillationMultiplier;
 	}
 
 	public boolean getDefaultRail3D() {
@@ -68,6 +73,10 @@ public final class Client extends ClientSchema {
 
 	public void setDynamicTextureResolution(int dynamicTextureResolution) {
 		this.dynamicTextureResolution = Utilities.clamp(dynamicTextureResolution, 0, DYNAMIC_RESOLUTION_COUNT);
+	}
+
+	public void setVehicleOscillationMultiplier(double trainOscillationMultiplier) {
+		this.vehicleOscillationMultiplier = Utilities.clamp(trainOscillationMultiplier, 0, (TRAIN_OSCILLATION_COUNT / 10.0));
 	}
 
 	public void toggleDefaultRail3D() {

--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
@@ -10,6 +10,7 @@ import org.mtr.mapping.mapper.GraphicsHolder;
 import org.mtr.mapping.mapper.OptimizedRenderer;
 import org.mtr.mod.Init;
 import org.mtr.mod.client.*;
+import org.mtr.mod.config.Config;
 import org.mtr.mod.data.IGui;
 import org.mtr.mod.resource.VehicleResource;
 import org.mtr.mod.resource.VehicleResourceCache;
@@ -106,7 +107,7 @@ public class RenderVehicles implements IGui {
 						} else {
 							openDoorways = vehicleResourceCache.doorways.stream().filter(doorway -> RenderVehicleHelper.canOpenDoors(doorway, renderVehicleTransformationHelperAbsolute, vehicle.persistentVehicleData.getDoorValue(), false)).collect(Collectors.toCollection(ObjectArrayList::new));
 						}
-						final double oscillationAmount = vehicle.persistentVehicleData.getOscillation(carNumber).getAmount();
+						final double oscillationAmount = vehicle.persistentVehicleData.getOscillation(carNumber).getAmount() * Config.getClient().getVehicleOscillationMultiplier();
 
 						if (canRide) {
 							if (vehicleResourceCache != null) {

--- a/fabric/src/main/java/org/mtr/mod/screen/ConfigScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/ConfigScreen.java
@@ -54,7 +54,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 			button.setMessage(client.getLanguageDisplay().translationKey.getText());
 		});
 		sliderDynamicTextureResolution = new WidgetShorterSlider(0, 0, Client.DYNAMIC_RESOLUTION_COUNT - 1, String::valueOf, null);
-		sliderTrainOscillationMultiplier = new WidgetShorterSlider(0, 0, Client.TRAIN_OSCILLATION_COUNT, i -> String.valueOf(i / 10.0), null);
+		sliderTrainOscillationMultiplier = new WidgetShorterSlider(0, 0, Client.TRAIN_OSCILLATION_COUNT, i -> (i * 10) + "%", null);
 		buttonDefaultRail3D = new ButtonWidgetExtension(0, 0, 0, BUTTON_HEIGHT, TextHelper.literal(""), button -> {
 			client.toggleDefaultRail3D();
 			setButtonText(button, client.getDefaultRail3D());
@@ -80,7 +80,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 		IDrawing.setPositionAndWidth(buttonHideTranslucentParts, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonLanguageOptions, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(sliderDynamicTextureResolution, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH - TEXT_PADDING - GraphicsHolder.getTextWidth("100%"));
-		IDrawing.setPositionAndWidth(sliderTrainOscillationMultiplier, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH - TEXT_PADDING - GraphicsHolder.getTextWidth("1.5"));
+		IDrawing.setPositionAndWidth(sliderTrainOscillationMultiplier, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH - TEXT_PADDING - GraphicsHolder.getTextWidth("100%"));
 		IDrawing.setPositionAndWidth(buttonDefaultRail3D, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonUseMTRFont, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonDisableShadowsForShaders, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);

--- a/fabric/src/main/java/org/mtr/mod/screen/ConfigScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/ConfigScreen.java
@@ -25,6 +25,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 	private final ButtonWidgetExtension buttonHideTranslucentParts;
 	private final ButtonWidgetExtension buttonLanguageOptions;
 	private final WidgetShorterSlider sliderDynamicTextureResolution;
+	private final WidgetShorterSlider sliderTrainOscillationMultiplier;
 	private final ButtonWidgetExtension buttonDefaultRail3D;
 	private final ButtonWidgetExtension buttonUseMTRFont;
 	private final ButtonWidgetExtension buttonDisableShadowsForShaders;
@@ -53,6 +54,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 			button.setMessage(client.getLanguageDisplay().translationKey.getText());
 		});
 		sliderDynamicTextureResolution = new WidgetShorterSlider(0, 0, Client.DYNAMIC_RESOLUTION_COUNT - 1, String::valueOf, null);
+		sliderTrainOscillationMultiplier = new WidgetShorterSlider(0, 0, Client.TRAIN_OSCILLATION_COUNT, i -> String.valueOf(i / 10.0), null);
 		buttonDefaultRail3D = new ButtonWidgetExtension(0, 0, 0, BUTTON_HEIGHT, TextHelper.literal(""), button -> {
 			client.toggleDefaultRail3D();
 			setButtonText(button, client.getDefaultRail3D());
@@ -78,6 +80,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 		IDrawing.setPositionAndWidth(buttonHideTranslucentParts, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonLanguageOptions, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(sliderDynamicTextureResolution, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH - TEXT_PADDING - GraphicsHolder.getTextWidth("100%"));
+		IDrawing.setPositionAndWidth(sliderTrainOscillationMultiplier, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH - TEXT_PADDING - GraphicsHolder.getTextWidth("1.5"));
 		IDrawing.setPositionAndWidth(buttonDefaultRail3D, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonUseMTRFont, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
 		IDrawing.setPositionAndWidth(buttonDisableShadowsForShaders, width - SQUARE_SIZE - BUTTON_WIDTH, BUTTON_HEIGHT * (i++) + SQUARE_SIZE, BUTTON_WIDTH);
@@ -91,6 +94,8 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 		buttonLanguageOptions.setMessage2(client.getLanguageDisplay().translationKey.getText());
 		sliderDynamicTextureResolution.setHeight(BUTTON_HEIGHT);
 		sliderDynamicTextureResolution.setValue(client.getDynamicTextureResolution());
+		sliderTrainOscillationMultiplier.setHeight(BUTTON_HEIGHT);
+		sliderTrainOscillationMultiplier.setValue((int)(client.getVehicleOscillationMultiplier() * 10));
 		buttonDefaultRail3D.active = OptimizedRenderer.hasOptimizedRendering();
 		buttonSupportPatreon.setMessage2(TranslationProvider.GUI_MTR_SUPPORT.getText());
 
@@ -99,6 +104,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 		addChild(new ClickableWidget(buttonHideTranslucentParts));
 		addChild(new ClickableWidget(buttonLanguageOptions));
 		addChild(new ClickableWidget(sliderDynamicTextureResolution));
+		addChild(new ClickableWidget(sliderTrainOscillationMultiplier));
 		addChild(new ClickableWidget(buttonDefaultRail3D));
 		addChild(new ClickableWidget(buttonUseMTRFont));
 		addChild(new ClickableWidget(buttonDisableShadowsForShaders));
@@ -118,6 +124,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_HIDE_TRANSLUCENT_PARTS.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_LANGUAGE_OPTIONS.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_DYNAMIC_TEXTURE_RESOLUTION.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
+			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_VEHICLE_OSCILLATION_MULTIPLIER.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_DEFAULT_RAIL_3D.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_USE_MTR_FONT.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
 			graphicsHolder.drawText(TranslationProvider.OPTIONS_MTR_DISABLE_SHADOWS_FOR_SHADERS.getMutableText(), SQUARE_SIZE, BUTTON_HEIGHT * (i++) + yStart1, ARGB_WHITE, false, GraphicsHolder.getDefaultLight());
@@ -158,6 +165,7 @@ public class ConfigScreen extends MTRScreenBase implements IGui {
 	public void onClose2() {
 		super.onClose2();
 		client.setDynamicTextureResolution(sliderDynamicTextureResolution.getIntValue());
+		client.setVehicleOscillationMultiplier(sliderTrainOscillationMultiplier.getIntValue() / 10.0);
 		DynamicTextureCache.instance.reload();
 		Config.save();
 	}

--- a/fabric/src/main/resources/assets/mtr/lang/en_us.json
+++ b/fabric/src/main/resources/assets/mtr/lang/en_us.json
@@ -525,6 +525,7 @@
 	"options.mtr.shift_to_toggle_sitting": "Use %s to toggle sitting inside vehicles",
 	"options.mtr.show_announcement_messages": "Show \"next station\" messages in chat",
 	"options.mtr.support_patreon": "Support the mod on Patreon!",
+	"options.mtr.vehicle_oscillation_multiplier": "Vehicle sway effect strength",
 	"options.mtr.use_mtr_font": "Use custom MTR fonts (might not work on some computers)",
 	"options.mtr.use_tts_announcements": "Enable \"next station\" text-to-speech announcements",
 	"sign.mtr.airport": "機場|Airport",


### PR DESCRIPTION
As vehicle oscillation is purely cosmetic and different people have different level of acceptance, it's probably best to make an option where player can tweak to their liking.

This adds an option in the config screen to allow changing how much the vehicle sways. By default it is 1.0x (Same as before)
Those who like to turn off completely can move the slider all the way down to 0x