### PR TITLE
Fix: BVE Sound getting cut off at times

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/data/PersistentVehicleData.java
+++ b/fabric/src/main/java/org/mtr/mod/data/PersistentVehicleData.java
@@ -102,6 +102,12 @@ public final class PersistentVehicleData {
 		return getElement(vehicleSoundBaseList, carNumber, vehicleResource.createVehicleSoundBase);
 	}
 
+	public void dispose() {
+		for(VehicleSoundBase sounds : vehicleSoundBaseList) {
+			sounds.dispose();
+		}
+	}
+
 	private static <T> T getElement(ObjectArrayList<T> list, int index, Supplier<T> supplier) {
 		while (list.size() <= index) {
 			list.add(supplier.get());

--- a/fabric/src/main/java/org/mtr/mod/data/VehicleExtension.java
+++ b/fabric/src/main/java/org/mtr/mod/data/VehicleExtension.java
@@ -280,4 +280,11 @@ public class VehicleExtension extends Vehicle implements Utilities {
 			return stringBuilder.toString();
 		}
 	}
+
+	/**
+	 * Dispose the vehicle and execute the associated clean-up work, such as stopping vehicle sounds.
+	 */
+	public void dispose() {
+		persistentVehicleData.dispose();
+	}
 }

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateVehiclesLifts.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketUpdateVehiclesLifts.java
@@ -8,6 +8,7 @@ import org.mtr.core.serializer.SerializedDataBase;
 import org.mtr.core.serializer.WriterBase;
 import org.mtr.core.servlet.OperationProcessor;
 import org.mtr.core.tool.Utilities;
+import org.mtr.libraries.it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.longs.LongAVLTreeSet;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
@@ -40,8 +41,8 @@ public final class PacketUpdateVehiclesLifts extends PacketRequestResponseBase {
 	protected void runClientInbound(JsonReader jsonReader) {
 		final MinecraftClientData minecraftClientData = MinecraftClientData.getInstance();
 		final VehicleLiftResponse vehicleLiftResponse = new VehicleLiftResponse(jsonReader, minecraftClientData);
-		final boolean hasUpdate1 = updateVehiclesOrLifts(minecraftClientData.vehicles, vehicleLiftResponse::iterateVehiclesToKeep, vehicleLiftResponse::iterateVehiclesToUpdate, vehicleUpdate -> vehicleUpdate.getVehicle().getId(), vehicleUpdate -> new VehicleExtension(vehicleUpdate, minecraftClientData));
-		final boolean hasUpdate2 = updateVehiclesOrLifts(minecraftClientData.lifts, vehicleLiftResponse::iterateLiftsToKeep, vehicleLiftResponse::iterateLiftsToUpdate, NameColorDataBase::getId, lift -> lift);
+		final boolean hasUpdate1 = updateVehiclesOrLifts(minecraftClientData.vehicles, vehicleLiftResponse::iterateVehiclesToKeep, vehicleLiftResponse::iterateVehiclesToUpdate, VehicleExtension::dispose, vehicleUpdate -> vehicleUpdate.getVehicle().getId(), vehicleUpdate -> new VehicleExtension(vehicleUpdate, minecraftClientData));
+		final boolean hasUpdate2 = updateVehiclesOrLifts(minecraftClientData.lifts, vehicleLiftResponse::iterateLiftsToKeep, vehicleLiftResponse::iterateLiftsToUpdate, (removedLift) -> {}, NameColorDataBase::getId, lift -> lift);
 
 		vehicleLiftResponse.iterateSignalBlockUpdates(signalBlockUpdate -> minecraftClientData.railIdToBlockedSignalColors.put(signalBlockUpdate.getRailId(), signalBlockUpdate.getBlockedColors()));
 
@@ -82,7 +83,7 @@ public final class PacketUpdateVehiclesLifts extends PacketRequestResponseBase {
 		return PacketRequestResponseBase.ResponseType.NONE;
 	}
 
-	private static <T extends NameColorDataBase, U> boolean updateVehiclesOrLifts(ObjectArraySet<T> dataSet, Consumer<LongConsumer> iterateKeep, Consumer<Consumer<U>> iterateUpdate, ToLongFunction<U> getId, Function<U, T> createInstance) {
+	private static <T extends NameColorDataBase, U> boolean updateVehiclesOrLifts(ObjectArraySet<T> dataSet, Consumer<LongConsumer> iterateKeep, Consumer<Consumer<U>> iterateUpdate, Consumer<T> onRemove, ToLongFunction<U> getId, Function<U, T> createInstance) {
 		final LongAVLTreeSet keepIds = new LongAVLTreeSet();
 		iterateKeep.accept(keepIds::add);
 		VehicleRidingMovement.writeVehicleId(keepIds);
@@ -94,8 +95,16 @@ public final class PacketUpdateVehiclesLifts extends PacketRequestResponseBase {
 			updateIds.add(getId.applyAsLong(dataToUpdate));
 		});
 
-		final boolean removedItems = dataSet.removeIf(data -> !keepIds.contains(data.getId()) || updateIds.contains(data.getId()));
+		final Long2ObjectOpenHashMap<T> removedItems = new Long2ObjectOpenHashMap<>();
+		final boolean itemRemoved = dataSet.removeIf(data -> {
+			boolean shouldBeRemoved = !keepIds.contains(data.getId());
+			if(shouldBeRemoved) removedItems.put(data.getId(), data);
+			return shouldBeRemoved || updateIds.contains(data.getId());
+		});
 		dataSetToUpdate.forEach(dataToUpdate -> dataSet.add(createInstance.apply(dataToUpdate)));
-		return !dataSetToUpdate.isEmpty() || removedItems;
+		dataSet.forEach(e -> removedItems.remove(e.getId()));
+		removedItems.values().forEach(onRemove);
+
+		return !dataSetToUpdate.isEmpty() || itemRemoved;
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/servlet/ResourcePackCreatorOperationServlet.java
+++ b/fabric/src/main/java/org/mtr/mod/servlet/ResourcePackCreatorOperationServlet.java
@@ -88,7 +88,8 @@ public final class ResourcePackCreatorOperationServlet extends AbstractResourceP
 	}
 
 	public static void tick(long millisElapsed) {
-		if (System.currentTimeMillis() > motorSoundExpiry) {
+		if (System.currentTimeMillis() > motorSoundExpiry && vehicleSoundBase != null) {
+			vehicleSoundBase.dispose();
 			vehicleSoundBase = null;
 		}
 		if (vehicleSoundBase != null) {

--- a/fabric/src/main/java/org/mtr/mod/sound/BveVehicleSound.java
+++ b/fabric/src/main/java/org/mtr/mod/sound/BveVehicleSound.java
@@ -169,6 +169,11 @@ public class BveVehicleSound extends VehicleSoundBase {
 	}
 
 	@Override
+	public void dispose() {
+		vehicleLoopingSoundHolder.dispose();
+	}
+
+	@Override
 	protected double getDoorCloseSoundTime() {
 		return config.config.doorCloseSoundLength;
 	}
@@ -209,6 +214,17 @@ public class BveVehicleSound extends VehicleSoundBase {
 			this.soundLoopNoise = soundLoopNoise;
 			this.soundLoopShoe = soundLoopShoe;
 			this.soundLoopCompressor = soundLoopCompressor;
+		}
+
+		public void dispose() {
+			for(VehicleLoopingSoundInstance instance : soundLoopMotor) {
+				if(instance != null) instance.dispose();
+			}
+			if(soundLoopRun != null) soundLoopRun.dispose();
+			if(soundLoopFlange != null) soundLoopFlange.dispose();
+			if(soundLoopNoise != null) soundLoopNoise.dispose();
+			if(soundLoopShoe != null) soundLoopShoe.dispose();
+			if(soundLoopCompressor != null) soundLoopCompressor.dispose();
 		}
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/sound/LegacyVehicleSound.java
+++ b/fabric/src/main/java/org/mtr/mod/sound/LegacyVehicleSound.java
@@ -57,6 +57,10 @@ public class LegacyVehicleSound extends VehicleSoundBase {
 	}
 
 	@Override
+	public void dispose() {
+	}
+
+	@Override
 	protected void playDoorSound(BlockPos blockPos, boolean isOpen) {
 		ScheduledSound.schedule(blockPos, SoundHelper.createSoundEvent(new Identifier(Init.MOD_ID, String.format("%s%s", legacyDoorSoundBaseResource, isOpen ? SOUND_DOOR_OPEN : SOUND_DOOR_CLOSE))), 2, 1);
 	}

--- a/fabric/src/main/java/org/mtr/mod/sound/VehicleLoopingSoundInstance.java
+++ b/fabric/src/main/java/org/mtr/mod/sound/VehicleLoopingSoundInstance.java
@@ -5,9 +5,6 @@ import org.mtr.mapping.mapper.MovingSoundInstanceExtension;
 
 public class VehicleLoopingSoundInstance extends MovingSoundInstanceExtension {
 
-	private int cooldown;
-	private static final int MAX_DISTANCE = 64;
-
 	public VehicleLoopingSoundInstance(SoundEvent event) {
 		super(event, SoundCategory.getBlocksMapped());
 		setIsRepeatableMapped(true);
@@ -17,16 +14,11 @@ public class VehicleLoopingSoundInstance extends MovingSoundInstanceExtension {
 	}
 
 	public void setData(float volume, float pitch, BlockPos blockPos) {
-		cooldown = 20;
 		setPitch(pitch == 0 ? 1 : pitch);
 		setVolume(volume);
-
-		final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
-		if (clientPlayerEntity != null && clientPlayerEntity.getBlockPos().getManhattanDistance(new Vector3i(blockPos.data)) < MAX_DISTANCE) {
-			setX(blockPos.getX());
-			setY(blockPos.getY());
-			setZ(blockPos.getZ());
-		}
+		setX(blockPos.getX());
+		setY(blockPos.getY());
+		setZ(blockPos.getZ());
 
 		final SoundManager soundManager = MinecraftClient.getInstance().getSoundManager();
 		if (volume > 0 && !soundManager.isPlaying(new SoundInstance(this))) {
@@ -37,11 +29,6 @@ public class VehicleLoopingSoundInstance extends MovingSoundInstanceExtension {
 
 	@Override
 	public void tick2() {
-		if (cooldown == 0) {
-			setDone2();
-		} else {
-			cooldown--;
-		}
 	}
 
 	@Override
@@ -52,5 +39,9 @@ public class VehicleLoopingSoundInstance extends MovingSoundInstanceExtension {
 	@Override
 	public boolean canPlay2() {
 		return true;
+	}
+
+	public void dispose() {
+		setDone2();
 	}
 }

--- a/fabric/src/main/java/org/mtr/mod/sound/VehicleSoundBase.java
+++ b/fabric/src/main/java/org/mtr/mod/sound/VehicleSoundBase.java
@@ -15,6 +15,8 @@ public abstract class VehicleSoundBase {
 		}
 	}
 
+	public abstract void dispose();
+
 	protected abstract void playDoorSound(BlockPos blockPos, boolean isOpen);
 
 	protected abstract double getDoorCloseSoundTime();


### PR DESCRIPTION
Explicitly dispose BVE sounds when vehicles gets removed instead of relying on timeout, which is not always reliable.