### PR TITLE
Fixed the position definition of some parts in Eidan 9000.

### DIFF
--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
@@ -184,7 +184,7 @@
 				"roof_door_light"
 			],
 			"positionDefinitions": [
-				"window"
+				"door"
 			],
 			"condition": "NORMAL",
 			"renderStage": "LIGHT",

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_2.json
@@ -93,7 +93,7 @@
 				"head_driver"
 			],
 			"positionDefinitions": [
-				"8b527750"
+				"cab_backward"
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "EXTERIOR",


### PR DESCRIPTION
![2025-05-21_23 47 04](https://github.com/user-attachments/assets/3a26418d-0ba1-426f-ab45-ade8c4f0cd61)
![2025-05-21_23 47 11](https://github.com/user-attachments/assets/8c536436-2591-44b2-b400-22e6d179053d)
A mistake was discovered in the installation of the image, so it has been corrected. We apologize for the inconvenience.