### PR TITLE
Change PreviousConnectionPositions to public

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
@@ -612,7 +612,7 @@ public class RenderVehicles implements IGui {
 		}
 	}
 
-	private static class PreviousConnectionPositions {
+	public static class PreviousConnectionPositions {
 
 		private Vector position1;
 		private Vector position2;


### PR DESCRIPTION
Tianjin Metro mod added the "disable train render" feature, which required skipping rendering train connectors.

```java
@Inject(at = @At("HEAD"), method = "renderConnection", cancellable = true, remap = false)
private static void beforeRenderConnection(boolean shouldRender1, boolean shouldRender2, boolean canHaveLight, RenderVehicles.PreviousConnectionPositions previousConnectionPositions, Identifier innerSideTexture, Identifier innerTopTexture, Identifier innerBottomTexture, Identifier outerSideTexture, Identifier outerTopTexture, Identifier outerBottomTexture, PositionAndRotation positionAndRotation, boolean useOffset, double vehicleLength, double width, double height, double yOffset, double zOffset, double oscillationAmount, boolean isOnRoute, CallbackInfo ci) {
    if (ConfigClient.DISABLE_TRAIN_RENDERING.get()) ci.cancel();
}
```

Due to `RenderVehicles.PreviousConnectionPositions` is private, this injector is not working.