### PR TITLE
Improve Legacy OBJ Resource Pack Compatibility

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/resource/CustomResourceTools.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/CustomResourceTools.java
@@ -27,13 +27,17 @@ public interface CustomResourceTools extends SerializedDataBase {
 	}
 
 	static String formatIdentifierString(String text) {
-		return Arrays.stream(text.split(":")).map(textPart -> textPart.replaceAll("[^a-z0-9/._-]", "")).collect(Collectors.joining(":"));
+		return Arrays.stream(text.toLowerCase(Locale.ROOT).split(":")).map(textPart -> textPart.replaceAll("[^a-z0-9/._-]", "_")).collect(Collectors.joining(":"));
 	}
 
 	static Identifier getResourceFromSamePath(String basePath, String resource, String extension) {
-		final String[] resourceSplit = basePath.split("/");
-		resourceSplit[resourceSplit.length - 1] = resource;
-		return CustomResourceTools.formatIdentifierWithDefault(String.join("/", resourceSplit), extension);
+		if(resource.contains(":")) { // Assume it is already an identifier
+			return formatIdentifierWithDefault(resource, extension);
+		} else {
+			final String[] resourceSplit = basePath.split("/");
+			resourceSplit[resourceSplit.length - 1] = resource;
+			return formatIdentifierWithDefault(String.join("/", resourceSplit), extension);
+		}
 	}
 
 	static int colorStringToInt(String color) {

--- a/fabric/src/main/java/org/mtr/mod/resource/OptimizedModelWrapper.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/OptimizedModelWrapper.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class OptimizedModelWrapper {
+	/** Used as a fallback texture if a face does not have a texture */
+	public static final Identifier WHITE_TEXTURE = new Identifier("minecraft:textures/misc/white.png");
 
 	@Nullable
 	final OptimizedModel optimizedModel;

--- a/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
@@ -41,7 +41,7 @@ public interface StoredModelResourceBase {
 			final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
 					resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "obj")),
 					mtlString -> resourceProvider.get(CustomResourceTools.getResourceFromSamePath(modelResource, mtlString, "mtl")),
-					textureString -> StringUtils.isEmpty(textureString) ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
+					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
 					null, true, flipTextureV
 			));
 			transform(rawModels.values());

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleModel.java
@@ -133,7 +133,7 @@ public final class VehicleModel extends VehicleModelSchema {
 			final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(new Object2ObjectAVLTreeMap<>(OptimizedModel.ObjModel.loadModel(
 					resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "obj")),
 					mtlString -> resourceProvider.get(CustomResourceTools.getResourceFromSamePath(modelResource, mtlString, "mtl")),
-					textureString -> StringUtils.isEmpty(textureString) ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
+					textureString -> StringUtils.isEmpty(textureString) ? OptimizedModelWrapper.WHITE_TEXTURE : StringUtils.equals(textureString, "default.png") ? textureId : CustomResourceTools.getResourceFromSamePath(modelResource, textureString, "png"),
 					null, true, flipTextureV
 			)), textureId, modelProperties, positionDefinitions, id);
 			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();


### PR DESCRIPTION
- Instead of trimming all invalid identifier character in textures, it first converts all of them to lower-case first, and replaces it with an underscore character, which replicates the behavior in NTE.
- NTE allows specifying a texture identifier directly instead of resolving a relative texture file, now it does not attempt to resolve relatively if it contains a `:`, which is presumed to be a Minecraft Identifier.
- Under NTE, a material without a texture assigned behaves like a solid color (as it should) by rendering it with a solid white texture, the behavior is replicated in this PR.
- Under NTE, a `default.png` can be entered as a texture name in the material, which will be replaced with the specified texture id in mtr_custom_resources.json, now it also does that.

With the exception of packs utilizing NTE scripting & Complex blacklist/whitelist feature, most packs I can find on modrinth now works as-is from MTR 3 + NTE.