### PR TITLE
Add `packet_s2c` channel for the neoforge 1.21.1 dedicated server

### DIFF
--- a/src/main/java/org/mtr/neoforge/ModEventBus.java
+++ b/src/main/java/org/mtr/neoforge/ModEventBus.java
@@ -8,10 +8,12 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import org.mtr.MTR;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.packet.CustomPacketS2C;
 import org.mtr.packet.PacketBufferReceiver;
 import org.mtr.packet.PacketHandler;
 
@@ -26,7 +28,12 @@ public final class ModEventBus {
 	public static BiConsumer<ServerLevel, ChunkAccess> chunkUnloadConsumer = null;
 	public static final Object2ObjectOpenHashMap<String, Function<PacketBufferReceiver, ? extends PacketHandler>> PACKETS = new Object2ObjectOpenHashMap<>();
 	public static final ObjectArrayList<Consumer<PayloadRegistrar>> PAYLOAD_HANDLERS = new ObjectArrayList<>();
+	public static BiConsumer<CustomPacketS2C, IPayloadContext> s2cClientHandler = (packet, context) -> {};
 	private static final String PROTOCOL_VERSION = "1";
+
+	public static void handleS2CClient(CustomPacketS2C packet, IPayloadContext context) {
+		s2cClientHandler.accept(packet, context);
+	}
 
 	@SubscribeEvent
 	public static void chunkLoad(ChunkEvent.Load event) {

--- a/src/main/java/org/mtr/registry/RegistryClient.java
+++ b/src/main/java/org/mtr/registry/RegistryClient.java
@@ -91,13 +91,12 @@ public final class RegistryClient {
 //? }
 
 //? if neoforge {
-		/*ModEventBus.PAYLOAD_HANDLERS.add(payloadRegistrar -> payloadRegistrar.playBidirectional(MTR.PACKET_IDENTIFIER_S2C, StreamCodec.composite(ByteBufCodecs.BYTE_ARRAY, CustomPacketS2C::buffer, CustomPacketS2C::new), new DirectionalPayloadHandler<>((customPacketS2C, context) -> PacketBufferReceiver.receive(customPacketS2C.buffer(), packetBufferReceiver -> {
+		/*ModEventBus.s2cClientHandler = (customPacketS2C, context) -> PacketBufferReceiver.receive(customPacketS2C.buffer(), packetBufferReceiver -> {
 			final Function<PacketBufferReceiver, ? extends PacketHandler> getInstance = ModEventBus.PACKETS.get(packetBufferReceiver.readString());
 			if (getInstance != null) {
 				getInstance.apply(packetBufferReceiver).runClient();
 			}
-		}, Minecraft.getInstance()::execute), (customPacketS2C, context) -> {
-		})));
+		}, Minecraft.getInstance()::execute);
 *///? }
 	}
 

--- a/src/main/java/org/mtr/registry/RegistryServer.java
+++ b/src/main/java/org/mtr/registry/RegistryServer.java
@@ -191,6 +191,8 @@ public final class RegistryServer {
 				}, ((ServerPlayer) player).server::execute);
 			}
 		})));
+		ModEventBus.PAYLOAD_HANDLERS.add(payloadRegistrar -> payloadRegistrar.playBidirectional(MTR.PACKET_IDENTIFIER_S2C, StreamCodec.composite(ByteBufCodecs.BYTE_ARRAY, CustomPacketS2C::buffer, CustomPacketS2C::new), new DirectionalPayloadHandler<>(ModEventBus::handleS2CClient, (customPacketS2C, context) -> {
+		})));
 *///? }
 	}
 


### PR DESCRIPTION
Closes #1421.

When running MTR Neoforge 1.21.1 on dedicated server, clients are not able to connect to it:
```
[12:44:44] [Render thread/WARN] [ne.ne.ne.cl.gu.ModMismatchDisconnectedScreen/]: Channel [mtr:packet_s2c] failed to connect: Channel of mod "Minecraft Transit Railway" failed to connect: This channel is missing on the server side, but required on the client!
[12:44:44] [Render thread/WARN] [minecraft/ClientCommonPacketListenerImpl]: Client disconnected with reason: Incompatible client! Please use NeoForge 21.1.233
```

It seems that the server doesn't initialize the `packet_s2c` channel. This PR adds init for this channel.
The client is able to connect with the server after the fix.