### PR TITLE
Optimize OBJ usemtl emission

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
@@ -182,8 +182,13 @@ public final class MqoModelConverter {
 					}
 				}
 
+				String lastMaterialName = null;
 				for (final Triangle triangle : triangles) {
-					objBuilder.append("usemtl ").append(triangle.materialIndex >= 0 && triangle.materialIndex < materials.size() ? getMaterialName(triangle.materialIndex) : "mqo_default").append('\n');
+					final String materialName = triangle.materialIndex >= 0 && triangle.materialIndex < materials.size() ? getMaterialName(triangle.materialIndex) : "mqo_default";
+					if (!materialName.equals(lastMaterialName)) {
+						objBuilder.append("usemtl ").append(materialName).append('\n');
+						lastMaterialName = materialName;
+					}
 					for (int i = 0; i < 3; i++) {
 						if (triangle.hasUv) {
 							objBuilder.append(String.format(Locale.US, "vt %.6f %.6f%n", triangle.u[i], triangle.v[i]));

--- a/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/MqoModelConverter.java
@@ -32,14 +32,8 @@ public final class MqoModelConverter {
 	}
 
 	private static int findStringEnd(String text, int startIndex) {
-		boolean escaped = false;
 		for (int i = startIndex; i < text.length(); i++) {
-			final char character = text.charAt(i);
-			if (escaped) {
-				escaped = false;
-			} else if (character == '\\') {
-				escaped = true;
-			} else if (character == '"') {
+			if (text.charAt(i) == '"') {
 				return i;
 			}
 		}
@@ -239,7 +233,11 @@ public final class MqoModelConverter {
 
 		private void parseObjectChunk() {
 			final String objectHeader = lines[index++].trim();
-			final MqoObject object = new MqoObject(extractQuotedOrFirstToken(objectHeader.substring("Object".length()).replace("{", "").trim()));
+			String objectName = objectHeader.substring("Object".length()).trim();
+			if (objectName.endsWith("{")) {
+				objectName = objectName.substring(0, objectName.length() - 1).trim();
+			}
+			final MqoObject object = new MqoObject(extractQuotedOrFirstToken(objectName));
 
 			while (index < lines.length) {
 				final String line = lines[index].trim();

--- a/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
+++ b/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
@@ -93,6 +93,31 @@ public final class MqoModelConverterTest {
 	}
 
 	@Test
+	public void onlyWriteUsemtlWhenMaterialChanges() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Material 1 {",
+				"	\"body\"",
+				"}",
+				"Object \"body\" {",
+				"	vertex 4 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		1 1 0",
+				"		0 1 0",
+				"	}",
+				"	face 2 {",
+				"		3 V(0 1 2) M(0)",
+				"		3 V(0 2 3) M(0)",
+				"	}",
+				"}"
+		));
+
+		Assertions.assertEquals(1, convertedModel.getObjContent().split("usemtl mqo_material_0", -1).length - 1);
+	}
+
+	@Test
 	public void convertSmoothNormals() {
 		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
 				"Metasequoia Document",

--- a/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
+++ b/fabric/src/test/java/org/mtr/test/MqoModelConverterTest.java
@@ -142,6 +142,51 @@ public final class MqoModelConverterTest {
 	}
 
 	@Test
+	public void preserveObjectNameCharactersInsideQuotes() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Object \"body { section}\\\" {",
+				"	vertex 3 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"	}",
+				"	face 1 {",
+				"		3 V(0 1 2)",
+				"	}",
+				"}"
+		));
+
+		Assertions.assertEquals("body { section}\\", convertedModel.getModelParts().get(0));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("o body { section}\\"));
+		Assertions.assertTrue(convertedModel.getObjContent().contains("g body { section}\\"));
+	}
+
+	@Test
+	public void preserveBackslashesInTexturePath() {
+		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
+				"Metasequoia Document",
+				"Format Text Ver 1.1",
+				"Material 1 {",
+				"	\"window\" tex(\"textures\\\\cars\\\\window.png\")",
+				"}",
+				"Object \"window\" {",
+				"	vertex 3 {",
+				"		0 0 0",
+				"		1 0 0",
+				"		0 1 0",
+				"	}",
+				"	face 1 {",
+				"		3 V(0 1 2) M(0)",
+				"	}",
+				"}"
+		));
+
+		Assertions.assertTrue(convertedModel.getMtlContent().contains("map_Kd textures\\\\cars\\\\window.png"));
+	}
+
+	@Test
 	public void ignoreUnknownObjectChildChunks() {
 		final MqoModelConverter.ConvertedModel convertedModel = MqoModelConverter.convert(mqo(
 				"Metasequoia Document",


### PR DESCRIPTION
Update `MqoModelConverter` to emit `usemtl` only when the material changes
Add a regression test to verify consecutive faces with the same material only generate one `usemtl`
