### PR TITLE
Add vehicle weather cover support for rain handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ subprojects {
 	}
 
 	tasks.withType(Javadoc).tap {
-		configureEach { javadoc.options.addStringOption("Xdoclint:none", "-quiet") }
+		configureEach {
+			javadoc.options.addStringOption("Xdoclint:none", "-quiet")
+			javadoc.options.encoding = "UTF-8"
+			javadoc.options.charSet = "UTF-8"
+			javadoc.options.docEncoding = "UTF-8"
+		}
 	}
 }

--- a/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
+++ b/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
@@ -78,11 +78,15 @@ public class BuildTools {
 	}
 
 	private void createEntityRainMixin(Path mixinPath) throws IOException {
+		final boolean fabric = isFabric();
+		final boolean legacyForge = isLegacyForge();
+		final String playerClass = legacyForge ? "ClientPlayerEntity" : fabric ? "ClientPlayerEntity" : "LocalPlayer";
+		final String rainMethod = fabric ? "isBeingRainedOn" : "isInRain";
 		FileUtils.writeStringToFile(mixinPath.resolve("EntityRainMixin.java").toFile(), String.join("\n",
 				"package org.mtr.mixin;",
 				"",
-				loader.equals("fabric") ? "import net.minecraft.client.network.ClientPlayerEntity;" : "import net.minecraft.client.player.LocalPlayer;",
-				loader.equals("fabric") ? "import net.minecraft.entity.Entity;" : "import net.minecraft.world.entity.Entity;",
+				legacyForge ? "import net.minecraft.client.entity.player.ClientPlayerEntity;" : fabric ? "import net.minecraft.client.network.ClientPlayerEntity;" : "import net.minecraft.client.player.LocalPlayer;",
+				legacyForge ? "import net.minecraft.entity.Entity;" : fabric ? "import net.minecraft.entity.Entity;" : "import net.minecraft.world.entity.Entity;",
 				"import org.mtr.mod.client.VehicleWeatherCover;",
 				"import org.spongepowered.asm.mixin.Mixin;",
 				"import org.spongepowered.asm.mixin.injection.At;",
@@ -92,10 +96,10 @@ public class BuildTools {
 				"@Mixin(Entity.class)",
 				"public abstract class EntityRainMixin {",
 				"",
-				loader.equals("fabric") ? "\t@Inject(method = \"isBeingRainedOn\", at = @At(\"RETURN\"), cancellable = true)" : "\t@Inject(method = \"isInRain\", at = @At(\"RETURN\"), cancellable = true)",
-				loader.equals("fabric") ? "\tprivate void isBeingRainedOn(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {" : "\tprivate void isInRain(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {",
+				String.format("\t@Inject(method = \"%s\", at = @At(\"RETURN\"), cancellable = true)", rainMethod),
+				String.format("\tprivate void %s(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {", rainMethod),
 				"\t\tfinal Entity entity = (Entity) (Object) this;",
-				loader.equals("fabric") ? "\t\tif (callbackInfoReturnable.getReturnValueZ() && entity instanceof ClientPlayerEntity && VehicleWeatherCover.hasWeatherCoverAt(entity.getX(), entity.getY(), entity.getZ())) {" : "\t\tif (callbackInfoReturnable.getReturnValueZ() && entity instanceof LocalPlayer && VehicleWeatherCover.hasWeatherCoverAt(entity.getX(), entity.getY(), entity.getZ())) {",
+				String.format("\t\tif (callbackInfoReturnable.getReturnValueZ() && entity instanceof %s && VehicleWeatherCover.hasWeatherCoverAt(entity.getX(), entity.getY(), entity.getZ())) {", playerClass),
 				"\t\t\tcallbackInfoReturnable.setReturnValue(false);",
 				"\t\t}",
 				"\t}",
@@ -105,56 +109,130 @@ public class BuildTools {
 	}
 
 	private void createWorldRendererWeatherMixin(Path mixinPath) throws IOException {
+		final boolean fabric = isFabric();
+		final boolean legacyForge = isLegacyForge();
+		final boolean oldPrecipitation = isOldPrecipitationApi();
+		final String worldRendererClass = fabric || legacyForge ? "WorldRenderer" : "LevelRenderer";
+		final String clientWorldClass = fabric || legacyForge ? "ClientWorld" : "ClientLevel";
+		final String particleClass = fabric ? "ParticleEffect" : legacyForge ? "IParticleData" : "ParticleOptions";
+		final String soundCategoryClass = fabric || legacyForge ? "SoundCategory" : "SoundSource";
+		final String weatherMethod = fabric ? "renderWeather" : "renderSnowAndRain";
+		final String rainTickMethod = fabric ? "tickRainSplashing" : "tickRain";
+		final String precipitationTarget;
+		final String precipitationMethodSignature;
+		final String precipitationReturn;
+		if (oldPrecipitation) {
+			final String precipitationType = legacyForge ? "RainType" : "Precipitation";
+			precipitationTarget = legacyForge
+					? "Lnet/minecraft/world/biome/Biome;getPrecipitation()Lnet/minecraft/world/biome/Biome$RainType;"
+					: fabric ? "Lnet/minecraft/world/biome/Biome;getPrecipitation()Lnet/minecraft/world/biome/Biome$Precipitation;" : "Lnet/minecraft/world/level/biome/Biome;getPrecipitation()Lnet/minecraft/world/level/biome/Biome$Precipitation;";
+			precipitationMethodSignature = String.format("\tprivate Biome.%s %sGetPrecipitation(Biome biome) {", precipitationType, weatherMethod);
+			precipitationReturn = String.format("\t\treturn VehicleWeatherCover.hasWeatherCoverAtPlayer() ? Biome.%s.NONE : biome.getPrecipitation();", precipitationType);
+		} else if (fabric) {
+			precipitationTarget = "Lnet/minecraft/world/biome/Biome;getPrecipitation(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/biome/Biome$Precipitation;";
+			precipitationMethodSignature = String.format("\tprivate Biome.Precipitation %sGetPrecipitation(Biome biome, BlockPos blockPos) {", weatherMethod);
+			precipitationReturn = "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitation(blockPos);";
+		} else {
+			precipitationTarget = "Lnet/minecraft/world/level/biome/Biome;getPrecipitationAt(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/biome/Biome$Precipitation;";
+			precipitationMethodSignature = String.format("\tprivate Biome.Precipitation %sGetPrecipitation(Biome biome, BlockPos blockPos) {", weatherMethod);
+			precipitationReturn = "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitationAt(blockPos);";
+		}
+		final String addParticleTarget;
+		if (fabric) {
+			addParticleTarget = "Lnet/minecraft/client/world/ClientWorld;addParticle(Lnet/minecraft/particle/ParticleEffect;DDDDDD)V";
+		} else if (legacyForge) {
+			addParticleTarget = "Lnet/minecraft/client/world/ClientWorld;addParticle(Lnet/minecraft/particles/IParticleData;DDDDDD)V";
+		} else {
+			addParticleTarget = "Lnet/minecraft/client/multiplayer/ClientLevel;addParticle(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V";
+		}
+		final String playSoundTarget;
+		final String playSoundSignature;
+		final String playSoundCall;
+		if (fabric && !oldPrecipitation) {
+			playSoundTarget = "Lnet/minecraft/client/world/ClientWorld;playSoundAtBlockCenter(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FFZ)V";
+			playSoundSignature = String.format("\tprivate void %sPlaySound(%s clientWorld, BlockPos blockPos, SoundEvent soundEvent, %s soundCategory, float volume, float pitch, boolean useDistance) {", rainTickMethod, clientWorldClass, soundCategoryClass);
+			playSoundCall = "\t\tclientWorld.playSoundAtBlockCenter(blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch, useDistance);";
+		} else if (legacyForge) {
+			playSoundTarget = "Lnet/minecraft/client/world/ClientWorld;playSound(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/SoundEvent;Lnet/minecraft/util/SoundCategory;FF)V";
+			playSoundSignature = String.format("\tprivate void %sPlaySound(%s clientWorld, PlayerEntity playerEntity, BlockPos blockPos, SoundEvent soundEvent, %s soundCategory, float volume, float pitch) {", rainTickMethod, clientWorldClass, soundCategoryClass);
+			playSoundCall = "\t\tclientWorld.playSound(playerEntity, blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch);";
+		} else if (fabric) {
+			playSoundTarget = "Lnet/minecraft/client/world/ClientWorld;playSound(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FFZ)V";
+			playSoundSignature = String.format("\tprivate void %sPlaySound(%s clientWorld, BlockPos blockPos, SoundEvent soundEvent, %s soundCategory, float volume, float pitch, boolean useDistance) {", rainTickMethod, clientWorldClass, soundCategoryClass);
+			playSoundCall = "\t\tclientWorld.playSound(blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch, useDistance);";
+		} else {
+			playSoundTarget = "Lnet/minecraft/client/multiplayer/ClientLevel;playLocalSound(Lnet/minecraft/core/BlockPos;Lnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FFZ)V";
+			playSoundSignature = String.format("\tprivate void %sPlaySound(%s clientWorld, BlockPos blockPos, SoundEvent soundEvent, %s soundCategory, float volume, float pitch, boolean useDistance) {", rainTickMethod, clientWorldClass, soundCategoryClass);
+			playSoundCall = "\t\tclientWorld.playLocalSound(blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch, useDistance);";
+		}
 		FileUtils.writeStringToFile(mixinPath.resolve("WorldRendererWeatherMixin.java").toFile(), String.join("\n",
 				"package org.mtr.mixin;",
 				"",
-				loader.equals("fabric") ? "import net.minecraft.client.MinecraftClient;" : "import net.minecraft.client.Minecraft;",
-				loader.equals("fabric") ? "import net.minecraft.client.network.ClientPlayerEntity;" : "import net.minecraft.client.multiplayer.ClientLevel;",
-				loader.equals("fabric") ? "import net.minecraft.client.render.WorldRenderer;" : "import net.minecraft.client.player.LocalPlayer;",
-				loader.equals("fabric") ? "import net.minecraft.client.world.ClientWorld;" : "import net.minecraft.client.renderer.LevelRenderer;",
-				loader.equals("fabric") ? "import net.minecraft.particle.ParticleEffect;" : "import net.minecraft.core.BlockPos;",
-				loader.equals("fabric") ? "import net.minecraft.sound.SoundCategory;" : "import net.minecraft.core.particles.ParticleOptions;",
-				loader.equals("fabric") ? "import net.minecraft.sound.SoundEvent;" : "import net.minecraft.sounds.SoundEvent;",
-				loader.equals("fabric") ? "import net.minecraft.util.math.BlockPos;" : "import net.minecraft.sounds.SoundSource;",
-				"import net.minecraft.world.biome.Biome;".replace("world.biome", loader.equals("fabric") ? "world.biome" : "world.level.biome"),
+				fabric ? "import net.minecraft.client.render.WorldRenderer;" : legacyForge ? "import net.minecraft.client.renderer.WorldRenderer;" : "import net.minecraft.client.renderer.LevelRenderer;",
+				fabric ? "import net.minecraft.client.world.ClientWorld;" : legacyForge ? "import net.minecraft.client.world.ClientWorld;" : "import net.minecraft.client.multiplayer.ClientLevel;",
+				fabric ? "import net.minecraft.particle.ParticleEffect;" : legacyForge ? "import net.minecraft.particles.IParticleData;" : "import net.minecraft.core.particles.ParticleOptions;",
+				fabric || legacyForge ? "import net.minecraft.util.math.BlockPos;" : "import net.minecraft.core.BlockPos;",
+				fabric ? "import net.minecraft.sound.SoundCategory;" : legacyForge ? "import net.minecraft.util.SoundCategory;" : "import net.minecraft.sounds.SoundSource;",
+				fabric ? "import net.minecraft.sound.SoundEvent;" : legacyForge ? "import net.minecraft.util.SoundEvent;" : "import net.minecraft.sounds.SoundEvent;",
+				legacyForge ? "import net.minecraft.entity.player.PlayerEntity;" : "",
+				fabric || legacyForge ? "import net.minecraft.world.biome.Biome;" : "import net.minecraft.world.level.biome.Biome;",
 				"import org.mtr.mod.client.VehicleWeatherCover;",
 				"import org.spongepowered.asm.mixin.Mixin;",
 				"import org.spongepowered.asm.mixin.injection.At;",
 				"import org.spongepowered.asm.mixin.injection.Redirect;",
 				"",
-				loader.equals("fabric") ? "@Mixin(WorldRenderer.class)" : "@Mixin(LevelRenderer.class)",
+				String.format("@Mixin(%s.class)", worldRendererClass),
 				"public abstract class WorldRendererWeatherMixin {",
 				"",
 				"\tprivate static final float RAIN_VOLUME_UNDER_WEATHER_COVER = 0.35F;",
 				"",
-				loader.equals("fabric") ? "\t@Redirect(method = \"renderWeather\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/world/biome/Biome;getPrecipitation(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/biome/Biome$Precipitation;\"))" : "\t@Redirect(method = \"renderSnowAndRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/world/level/biome/Biome;getPrecipitationAt(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/biome/Biome$Precipitation;\"))",
-				loader.equals("fabric") ? "\tprivate Biome.Precipitation renderWeatherGetPrecipitation(Biome biome, BlockPos blockPos) {" : "\tprivate Biome.Precipitation renderSnowAndRainGetPrecipitation(Biome biome, BlockPos blockPos) {",
-				loader.equals("fabric") ? "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitation(blockPos);" : "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitationAt(blockPos);",
+				String.format("\t@Redirect(method = \"%s\", at = @At(value = \"INVOKE\", target = \"%s\"))", weatherMethod, precipitationTarget),
+				precipitationMethodSignature,
+				precipitationReturn,
 				"\t}",
 				"",
-				loader.equals("fabric") ? "\t@Redirect(method = \"tickRainSplashing\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/world/ClientWorld;addParticle(Lnet/minecraft/particle/ParticleEffect;DDDDDD)V\"))" : "\t@Redirect(method = \"tickRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/multiplayer/ClientLevel;addParticle(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V\"))",
-				loader.equals("fabric") ? "\tprivate void tickRainSplashingAddParticle(ClientWorld clientWorld, ParticleEffect particleEffect, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {" : "\tprivate void tickRainAddParticle(ClientLevel clientLevel, ParticleOptions particleOptions, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {",
+				String.format("\t@Redirect(method = \"%s\", at = @At(value = \"INVOKE\", target = \"%s\"))", rainTickMethod, addParticleTarget),
+				String.format("\tprivate void %sAddParticle(%s clientWorld, %s particleEffect, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {", rainTickMethod, clientWorldClass, particleClass),
 				"\t\tif (!VehicleWeatherCover.hasWeatherCoverAt(x, y, z)) {",
-				loader.equals("fabric") ? "\t\t\tclientWorld.addParticle(particleEffect, x, y, z, velocityX, velocityY, velocityZ);" : "\t\t\tclientLevel.addParticle(particleOptions, x, y, z, velocityX, velocityY, velocityZ);",
+				"\t\t\tclientWorld.addParticle(particleEffect, x, y, z, velocityX, velocityY, velocityZ);",
 				"\t\t}",
 				"\t}",
 				"",
-				loader.equals("fabric") ? "\t@Redirect(method = \"tickRainSplashing\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/world/ClientWorld;playSoundAtBlockCenter(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FFZ)V\"))" : "\t@Redirect(method = \"tickRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/multiplayer/ClientLevel;playLocalSound(Lnet/minecraft/core/BlockPos;Lnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FFZ)V\"))",
-				loader.equals("fabric") ? "\tprivate void tickRainSplashingPlaySoundAtBlockCenter(ClientWorld clientWorld, BlockPos blockPos, SoundEvent soundEvent, SoundCategory soundCategory, float volume, float pitch, boolean useDistance) {" : "\tprivate void tickRainPlayLocalSound(ClientLevel clientLevel, BlockPos blockPos, SoundEvent soundEvent, SoundSource soundSource, float volume, float pitch, boolean distanceDelay) {",
-				loader.equals("fabric") ? "\t\tclientWorld.playSoundAtBlockCenter(blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch, useDistance);" : "\t\tclientLevel.playLocalSound(blockPos, soundEvent, soundSource, getRainVolume(volume), pitch, distanceDelay);",
+				String.format("\t@Redirect(method = \"%s\", at = @At(value = \"INVOKE\", target = \"%s\"))", rainTickMethod, playSoundTarget),
+				playSoundSignature,
+				playSoundCall,
 				"\t}",
 				"",
 				"\tprivate static float getRainVolume(float volume) {",
-				loader.equals("fabric") ? "\t\tfinal ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().player;" : "\t\tfinal LocalPlayer clientPlayerEntity = Minecraft.getInstance().player;",
-				"\t\tif (clientPlayerEntity == null) {",
-				"\t\t\treturn volume;",
-				"\t\t}",
-				"",
-				"\t\treturn VehicleWeatherCover.hasWeatherCoverAt(clientPlayerEntity.getX(), clientPlayerEntity.getY(), clientPlayerEntity.getZ()) ? volume * RAIN_VOLUME_UNDER_WEATHER_COVER : volume;",
+				"\t\treturn VehicleWeatherCover.hasWeatherCoverAtPlayer() ? volume * RAIN_VOLUME_UNDER_WEATHER_COVER : volume;",
 				"\t}",
 				"}",
 				""
 		), StandardCharsets.UTF_8);
+	}
+
+	private boolean isFabric() {
+		return loader.equals("fabric");
+	}
+
+	private boolean isLegacyMinecraftVersion() {
+		return majorVersion <= 16;
+	}
+
+	private boolean isMinecraftVersion17() {
+		return majorVersion == 17;
+	}
+
+	private boolean isModernMinecraftVersion() {
+		return majorVersion >= 18;
+	}
+
+	private boolean isLegacyForge() {
+		return !isFabric() && isLegacyMinecraftVersion();
+	}
+
+	private boolean isOldPrecipitationApi() {
+		return isLegacyMinecraftVersion() || isMinecraftVersion17() || (isModernMinecraftVersion() && (majorVersion < 19 || minecraftVersion.equals("1.19.2")));
 	}
 
 	public String getFabricVersion() {

--- a/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
+++ b/buildSrc/src/main/java/org/mtr/mod/BuildTools.java
@@ -73,6 +73,88 @@ public class BuildTools {
 		CreateClientWorldRenderingMixin.create(minecraftVersion, loader, mixinPath, "org.mtr.mixin");
 		CreatePlayerTeleportationStateAccessor.create(minecraftVersion, loader, mixinPath, "org.mtr.mixin");
 		CreatePlayerRendererOffsetMixin.create(minecraftVersion, loader, mixinPath, "org.mtr.mixin");
+		createEntityRainMixin(mixinPath);
+		createWorldRendererWeatherMixin(mixinPath);
+	}
+
+	private void createEntityRainMixin(Path mixinPath) throws IOException {
+		FileUtils.writeStringToFile(mixinPath.resolve("EntityRainMixin.java").toFile(), String.join("\n",
+				"package org.mtr.mixin;",
+				"",
+				loader.equals("fabric") ? "import net.minecraft.client.network.ClientPlayerEntity;" : "import net.minecraft.client.player.LocalPlayer;",
+				loader.equals("fabric") ? "import net.minecraft.entity.Entity;" : "import net.minecraft.world.entity.Entity;",
+				"import org.mtr.mod.client.VehicleWeatherCover;",
+				"import org.spongepowered.asm.mixin.Mixin;",
+				"import org.spongepowered.asm.mixin.injection.At;",
+				"import org.spongepowered.asm.mixin.injection.Inject;",
+				"import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;",
+				"",
+				"@Mixin(Entity.class)",
+				"public abstract class EntityRainMixin {",
+				"",
+				loader.equals("fabric") ? "\t@Inject(method = \"isBeingRainedOn\", at = @At(\"RETURN\"), cancellable = true)" : "\t@Inject(method = \"isInRain\", at = @At(\"RETURN\"), cancellable = true)",
+				loader.equals("fabric") ? "\tprivate void isBeingRainedOn(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {" : "\tprivate void isInRain(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {",
+				"\t\tfinal Entity entity = (Entity) (Object) this;",
+				loader.equals("fabric") ? "\t\tif (callbackInfoReturnable.getReturnValueZ() && entity instanceof ClientPlayerEntity && VehicleWeatherCover.hasWeatherCoverAt(entity.getX(), entity.getY(), entity.getZ())) {" : "\t\tif (callbackInfoReturnable.getReturnValueZ() && entity instanceof LocalPlayer && VehicleWeatherCover.hasWeatherCoverAt(entity.getX(), entity.getY(), entity.getZ())) {",
+				"\t\t\tcallbackInfoReturnable.setReturnValue(false);",
+				"\t\t}",
+				"\t}",
+				"}",
+				""
+		), StandardCharsets.UTF_8);
+	}
+
+	private void createWorldRendererWeatherMixin(Path mixinPath) throws IOException {
+		FileUtils.writeStringToFile(mixinPath.resolve("WorldRendererWeatherMixin.java").toFile(), String.join("\n",
+				"package org.mtr.mixin;",
+				"",
+				loader.equals("fabric") ? "import net.minecraft.client.MinecraftClient;" : "import net.minecraft.client.Minecraft;",
+				loader.equals("fabric") ? "import net.minecraft.client.network.ClientPlayerEntity;" : "import net.minecraft.client.multiplayer.ClientLevel;",
+				loader.equals("fabric") ? "import net.minecraft.client.render.WorldRenderer;" : "import net.minecraft.client.player.LocalPlayer;",
+				loader.equals("fabric") ? "import net.minecraft.client.world.ClientWorld;" : "import net.minecraft.client.renderer.LevelRenderer;",
+				loader.equals("fabric") ? "import net.minecraft.particle.ParticleEffect;" : "import net.minecraft.core.BlockPos;",
+				loader.equals("fabric") ? "import net.minecraft.sound.SoundCategory;" : "import net.minecraft.core.particles.ParticleOptions;",
+				loader.equals("fabric") ? "import net.minecraft.sound.SoundEvent;" : "import net.minecraft.sounds.SoundEvent;",
+				loader.equals("fabric") ? "import net.minecraft.util.math.BlockPos;" : "import net.minecraft.sounds.SoundSource;",
+				"import net.minecraft.world.biome.Biome;".replace("world.biome", loader.equals("fabric") ? "world.biome" : "world.level.biome"),
+				"import org.mtr.mod.client.VehicleWeatherCover;",
+				"import org.spongepowered.asm.mixin.Mixin;",
+				"import org.spongepowered.asm.mixin.injection.At;",
+				"import org.spongepowered.asm.mixin.injection.Redirect;",
+				"",
+				loader.equals("fabric") ? "@Mixin(WorldRenderer.class)" : "@Mixin(LevelRenderer.class)",
+				"public abstract class WorldRendererWeatherMixin {",
+				"",
+				"\tprivate static final float RAIN_VOLUME_UNDER_WEATHER_COVER = 0.35F;",
+				"",
+				loader.equals("fabric") ? "\t@Redirect(method = \"renderWeather\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/world/biome/Biome;getPrecipitation(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/biome/Biome$Precipitation;\"))" : "\t@Redirect(method = \"renderSnowAndRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/world/level/biome/Biome;getPrecipitationAt(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/biome/Biome$Precipitation;\"))",
+				loader.equals("fabric") ? "\tprivate Biome.Precipitation renderWeatherGetPrecipitation(Biome biome, BlockPos blockPos) {" : "\tprivate Biome.Precipitation renderSnowAndRainGetPrecipitation(Biome biome, BlockPos blockPos) {",
+				loader.equals("fabric") ? "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitation(blockPos);" : "\t\treturn VehicleWeatherCover.hasWeatherCoverAt(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5) ? Biome.Precipitation.NONE : biome.getPrecipitationAt(blockPos);",
+				"\t}",
+				"",
+				loader.equals("fabric") ? "\t@Redirect(method = \"tickRainSplashing\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/world/ClientWorld;addParticle(Lnet/minecraft/particle/ParticleEffect;DDDDDD)V\"))" : "\t@Redirect(method = \"tickRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/multiplayer/ClientLevel;addParticle(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V\"))",
+				loader.equals("fabric") ? "\tprivate void tickRainSplashingAddParticle(ClientWorld clientWorld, ParticleEffect particleEffect, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {" : "\tprivate void tickRainAddParticle(ClientLevel clientLevel, ParticleOptions particleOptions, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {",
+				"\t\tif (!VehicleWeatherCover.hasWeatherCoverAt(x, y, z)) {",
+				loader.equals("fabric") ? "\t\t\tclientWorld.addParticle(particleEffect, x, y, z, velocityX, velocityY, velocityZ);" : "\t\t\tclientLevel.addParticle(particleOptions, x, y, z, velocityX, velocityY, velocityZ);",
+				"\t\t}",
+				"\t}",
+				"",
+				loader.equals("fabric") ? "\t@Redirect(method = \"tickRainSplashing\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/world/ClientWorld;playSoundAtBlockCenter(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FFZ)V\"))" : "\t@Redirect(method = \"tickRain\", at = @At(value = \"INVOKE\", target = \"Lnet/minecraft/client/multiplayer/ClientLevel;playLocalSound(Lnet/minecraft/core/BlockPos;Lnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FFZ)V\"))",
+				loader.equals("fabric") ? "\tprivate void tickRainSplashingPlaySoundAtBlockCenter(ClientWorld clientWorld, BlockPos blockPos, SoundEvent soundEvent, SoundCategory soundCategory, float volume, float pitch, boolean useDistance) {" : "\tprivate void tickRainPlayLocalSound(ClientLevel clientLevel, BlockPos blockPos, SoundEvent soundEvent, SoundSource soundSource, float volume, float pitch, boolean distanceDelay) {",
+				loader.equals("fabric") ? "\t\tclientWorld.playSoundAtBlockCenter(blockPos, soundEvent, soundCategory, getRainVolume(volume), pitch, useDistance);" : "\t\tclientLevel.playLocalSound(blockPos, soundEvent, soundSource, getRainVolume(volume), pitch, distanceDelay);",
+				"\t}",
+				"",
+				"\tprivate static float getRainVolume(float volume) {",
+				loader.equals("fabric") ? "\t\tfinal ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().player;" : "\t\tfinal LocalPlayer clientPlayerEntity = Minecraft.getInstance().player;",
+				"\t\tif (clientPlayerEntity == null) {",
+				"\t\t\treturn volume;",
+				"\t\t}",
+				"",
+				"\t\treturn VehicleWeatherCover.hasWeatherCoverAt(clientPlayerEntity.getX(), clientPlayerEntity.getY(), clientPlayerEntity.getZ()) ? volume * RAIN_VOLUME_UNDER_WEATHER_COVER : volume;",
+				"\t}",
+				"}",
+				""
+		), StandardCharsets.UTF_8);
 	}
 
 	public String getFabricVersion() {

--- a/buildSrc/src/main/resources/schema/resource/modelPropertiesPart.json
+++ b/buildSrc/src/main/resources/schema/resource/modelPropertiesPart.json
@@ -27,7 +27,7 @@
 		},
 		"type": {
 			"$ref": "PartType",
-			"typeScriptEnum": "NORMAL|DISPLAY|FLOOR|DOORWAY|SEAT"
+			"typeScriptEnum": "NORMAL|DISPLAY|FLOOR|DOORWAY|WEATHER_COVER|WEATHER_COVER_FLOOR|SEAT"
 		},
 		"displayXPadding": {
 			"type": "number",

--- a/buildSrc/src/main/resources/schema/resource/modelPropertiesPartWrapper.json
+++ b/buildSrc/src/main/resources/schema/resource/modelPropertiesPartWrapper.json
@@ -19,7 +19,7 @@
 		},
 		"type": {
 			"$ref": "PartType",
-			"typeScriptEnum": "NORMAL|DISPLAY|FLOOR|DOORWAY|SEAT"
+			"typeScriptEnum": "NORMAL|DISPLAY|FLOOR|DOORWAY|WEATHER_COVER|WEATHER_COVER_FLOOR|SEAT"
 		},
 		"displayXPadding": {
 			"type": "number",

--- a/fabric/src/main/java/org/mtr/mod/client/VehicleRidingMovement.java
+++ b/fabric/src/main/java/org/mtr/mod/client/VehicleRidingMovement.java
@@ -288,6 +288,11 @@ public class VehicleRidingMovement {
 		return vehicleId == ridingVehicleId;
 	}
 
+	public static boolean hasWeatherCover() {
+		final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
+		return clientPlayerEntity != null && VehicleWeatherCover.hasWeatherCoverAt(clientPlayerEntity.getX(), clientPlayerEntity.getY(), clientPlayerEntity.getZ());
+	}
+
 	public static void overrideDoors() {
 		final double oldDoorOverrideTicks = doorOverrideTicks;
 		doorOverrideTicks = 2;

--- a/fabric/src/main/java/org/mtr/mod/client/VehicleWeatherCover.java
+++ b/fabric/src/main/java/org/mtr/mod/client/VehicleWeatherCover.java
@@ -6,6 +6,8 @@ import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import org.mtr.mapping.holder.Box;
+import org.mtr.mapping.holder.ClientPlayerEntity;
+import org.mtr.mapping.holder.MinecraftClient;
 import org.mtr.mapping.holder.Vector3d;
 import org.mtr.mod.InitClient;
 import org.mtr.mod.data.VehicleExtension;
@@ -29,6 +31,11 @@ public final class VehicleWeatherCover {
 		}
 
 		return false;
+	}
+
+	public static boolean hasWeatherCoverAtPlayer() {
+		final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
+		return clientPlayerEntity != null && hasWeatherCoverAt(clientPlayerEntity.getX(), clientPlayerEntity.getY(), clientPlayerEntity.getZ());
 	}
 
 	private static void refreshCache() {

--- a/fabric/src/main/java/org/mtr/mod/client/VehicleWeatherCover.java
+++ b/fabric/src/main/java/org/mtr/mod/client/VehicleWeatherCover.java
@@ -1,0 +1,99 @@
+package org.mtr.mod.client;
+
+import org.mtr.core.data.VehicleCar;
+import org.mtr.core.tool.Vector;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectImmutableList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
+import org.mtr.mapping.holder.Box;
+import org.mtr.mapping.holder.Vector3d;
+import org.mtr.mod.InitClient;
+import org.mtr.mod.data.VehicleExtension;
+import org.mtr.mod.render.PositionAndRotation;
+import org.mtr.mod.render.RenderVehicleHelper;
+import org.mtr.mod.resource.VehicleResourceCache;
+
+public final class VehicleWeatherCover {
+
+	private static final double WEATHER_COVER_CHECK_PADDING = 2;
+	private static final ObjectArrayList<CachedWeatherCover> cachedWeatherCovers = new ObjectArrayList<>();
+	private static long cachedGameTick = Long.MIN_VALUE;
+
+	public static boolean hasWeatherCoverAt(double x, double y, double z) {
+		refreshCache();
+
+		for (int i = 0; i < cachedWeatherCovers.size(); i++) {
+			if (cachedWeatherCovers.get(i).hasWeatherCoverAt(x, y, z)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static void refreshCache() {
+		final long gameTick = InitClient.getGameMillis() / 50;
+		if (cachedGameTick == gameTick) {
+			return;
+		}
+
+		cachedGameTick = gameTick;
+		cachedWeatherCovers.clear();
+
+		for (final VehicleExtension vehicle : MinecraftClientData.getInstance().vehicles) {
+			final ObjectArrayList<ObjectObjectImmutablePair<VehicleCar, ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>>>> vehicleCarsAndPositions = vehicle.getSmoothedVehicleCarsAndPositions(0);
+			for (int carNumber = 0; carNumber < vehicleCarsAndPositions.size(); carNumber++) {
+				addCachedWeatherCover(vehicle, vehicleCarsAndPositions.get(carNumber), carNumber);
+			}
+		}
+	}
+
+	private static void addCachedWeatherCover(VehicleExtension vehicle, ObjectObjectImmutablePair<VehicleCar, ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>>> vehicleCarAndPosition, int carNumber) {
+		final VehicleCar vehicleCar = vehicleCarAndPosition.left();
+		final VehicleResourceCache[] vehicleResourceCache = {null};
+		CustomResourceLoader.getVehicleById(vehicle.getTransportMode(), vehicleCar.getVehicleId(), vehicleResourceDetails -> vehicleResourceCache[0] = vehicleResourceDetails.left().getCachedVehicleResource(carNumber, vehicle.vehicleExtraData.immutableVehicleCars.size(), false));
+		if (vehicleResourceCache[0] == null || vehicleResourceCache[0].weatherCoverBoxes.isEmpty()) {
+			return;
+		}
+
+		final ObjectArrayList<PositionAndRotation> bogiePositions = new ObjectArrayList<>();
+		vehicleCarAndPosition.right().forEach(bogiePositionPair -> bogiePositions.add(new PositionAndRotation(bogiePositionPair.left(), bogiePositionPair.right(), true)));
+		final PositionAndRotation positionAndRotation = new PositionAndRotation(bogiePositions, vehicleCar, vehicle.getTransportMode().hasPitchAscending || vehicle.getTransportMode().hasPitchDescending);
+		final double longestDimension = vehicle.persistentVehicleData.longestDimensions[carNumber] + WEATHER_COVER_CHECK_PADDING;
+		cachedWeatherCovers.add(new CachedWeatherCover(positionAndRotation, longestDimension, vehicleResourceCache[0].weatherCoverBoxes));
+	}
+
+	private static final class CachedWeatherCover {
+
+		private final PositionAndRotation positionAndRotation;
+		private final double longestDimension;
+		private final ObjectImmutableList<Box> weatherCoverBoxes;
+
+		private CachedWeatherCover(PositionAndRotation positionAndRotation, double longestDimension, ObjectImmutableList<Box> weatherCoverBoxes) {
+			this.positionAndRotation = positionAndRotation;
+			this.longestDimension = longestDimension;
+			this.weatherCoverBoxes = weatherCoverBoxes;
+		}
+
+		private boolean hasWeatherCoverAt(double x, double y, double z) {
+			if (Math.abs(x - positionAndRotation.position.x) > longestDimension || Math.abs(y - positionAndRotation.position.y) > longestDimension || Math.abs(z - positionAndRotation.position.z) > longestDimension) {
+				return false;
+			}
+
+			final Vector3d relativePosition = positionAndRotation.transformBackwards(new Vector3d(x, y, z), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
+			final double relativeX = relativePosition.getXMapped();
+			final double relativeY = relativePosition.getYMapped();
+			final double relativeZ = relativePosition.getZMapped();
+			for (int i = 0; i < weatherCoverBoxes.size(); i++) {
+				if (RenderVehicleHelper.isBelowWeatherCover(weatherCoverBoxes.get(i), relativeX, relativeY, relativeZ)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	private VehicleWeatherCover() {
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/render/DynamicVehicleModel.java
+++ b/fabric/src/main/java/org/mtr/mod/render/DynamicVehicleModel.java
@@ -25,6 +25,7 @@ public final class DynamicVehicleModel extends EntityModelExtension<EntityAbstra
 	private final Identifier texture;
 	private final ObjectArraySet<Box> floors = new ObjectArraySet<>();
 	private final ObjectArraySet<Box> doorways = new ObjectArraySet<>();
+	private final ObjectArraySet<Box> weatherCoverBoxes = new ObjectArraySet<>();
 	private final Object2ObjectOpenHashMap<PartCondition, Object2ObjectOpenHashMap<RenderStage, OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartConditionAndRenderStage = new Object2ObjectOpenHashMap<>();
 	private final Object2ObjectOpenHashMap<PartCondition, Object2ObjectOpenHashMap<RenderStage, OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartConditionAndRenderStageDoorsClosed = new Object2ObjectOpenHashMap<>();
 	private final Object2ObjectOpenHashMap<PartCondition, Object2ObjectOpenHashMap<RenderStage, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>>> objModelsForPartConditionAndRenderStage = new Object2ObjectOpenHashMap<>();
@@ -65,7 +66,7 @@ public final class DynamicVehicleModel extends EntityModelExtension<EntityAbstra
 		modelProperties.addPartsIfEmpty(nameToPart.keySet());
 		this.texture = texture;
 		this.modelProperties = modelProperties;
-		modelProperties.iterateParts(modelPropertiesPart -> modelPropertiesPart.writeCache(texture, nameToPart, nameToDisplayParts, positionDefinitions, floors, doorways, materialGroupsForPartConditionAndRenderStage, materialGroupsForPartConditionAndRenderStageDoorsClosed));
+		modelProperties.iterateParts(modelPropertiesPart -> modelPropertiesPart.writeCache(texture, nameToPart, nameToDisplayParts, positionDefinitions, floors, doorways, weatherCoverBoxes, materialGroupsForPartConditionAndRenderStage, materialGroupsForPartConditionAndRenderStageDoorsClosed));
 		testDoors(id);
 	}
 
@@ -94,6 +95,7 @@ public final class DynamicVehicleModel extends EntityModelExtension<EntityAbstra
 	public void writeFloorsAndDoorways(
 			ObjectArrayList<Box> floors,
 			ObjectArrayList<Box> doorways,
+			ObjectArrayList<Box> weatherCoverBoxes,
 			Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartCondition,
 			Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartConditionDoorsClosed,
 			Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModelsForPartCondition,
@@ -101,6 +103,7 @@ public final class DynamicVehicleModel extends EntityModelExtension<EntityAbstra
 	) {
 		floors.addAll(this.floors);
 		doorways.addAll(this.doorways);
+		weatherCoverBoxes.addAll(this.weatherCoverBoxes);
 
 		materialGroupsForPartConditionAndRenderStage.forEach((partCondition, materialGroupsForRenderStage) -> Data.put(materialGroupsForPartCondition, partCondition, materialGroupsForRenderStage.values(), ObjectArrayList::new));
 		materialGroupsForPartConditionAndRenderStageDoorsClosed.forEach((partCondition, materialGroupsForRenderStage) -> Data.put(materialGroupsForPartConditionDoorsClosed, partCondition, materialGroupsForRenderStage.values(), ObjectArrayList::new));

--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicleHelper.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicleHelper.java
@@ -14,6 +14,8 @@ public class RenderVehicleHelper {
 	private static final int CHECK_DOOR_RADIUS_XZ = 1;
 	private static final int CHECK_DOOR_RADIUS_Y = 2;
 	private static final double RIDE_STEP_THRESHOLD = 0.75;
+	private static final double WEATHER_COVER_MIN_Y_OFFSET = 0.5;
+	private static final double WEATHER_COVER_HEAD_Y_OFFSET = 1.5;
 
 	/**
 	 * @return whether the doorway is close to platform blocks, unlocked platform screen doors, or unlocked automatic platform gates
@@ -117,6 +119,18 @@ public class RenderVehicleHelper {
 				box.getMinZMapped(),
 				box.getMaxZMapped()
 		);
+	}
+
+	public static boolean isBelowWeatherCover(Box weatherCoverBox, double playerX, double playerY, double playerZ) {
+		return Utilities.isBetween(
+				playerX,
+				weatherCoverBox.getMinXMapped(),
+				weatherCoverBox.getMaxXMapped()
+		) && Utilities.isBetween(
+				playerZ,
+				weatherCoverBox.getMinZMapped(),
+				weatherCoverBox.getMaxZMapped()
+		) && weatherCoverBox.getMinYMapped() >= playerY + WEATHER_COVER_MIN_Y_OFFSET && weatherCoverBox.getMaxYMapped() >= playerY + WEATHER_COVER_HEAD_Y_OFFSET;
 	}
 
 	private static void drawLine(GraphicsHolder graphicsHolder, Vector3d corner1, Vector3d corner2, Vector3d offset, int color) {

--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicleHelper.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicleHelper.java
@@ -73,10 +73,6 @@ public class RenderVehicleHelper {
 	public static void renderFloorOrDoorway(Box floorOrDoorway, int color, Vector3d playerPosition, PositionAndRotation positionAndRotation, boolean useOffset) {
 		final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
 		if (clientPlayerEntity != null && clientPlayerEntity.isHolding(Items.BRUSH.get())) {
-			final Vector3d corner1 = positionAndRotation.transformForwards(new Vector3d(floorOrDoorway.getMinXMapped(), floorOrDoorway.getMaxYMapped(), floorOrDoorway.getMinZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
-			final Vector3d corner2 = positionAndRotation.transformForwards(new Vector3d(floorOrDoorway.getMaxXMapped(), floorOrDoorway.getMaxYMapped(), floorOrDoorway.getMinZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
-			final Vector3d corner3 = positionAndRotation.transformForwards(new Vector3d(floorOrDoorway.getMaxXMapped(), floorOrDoorway.getMaxYMapped(), floorOrDoorway.getMaxZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
-			final Vector3d corner4 = positionAndRotation.transformForwards(new Vector3d(floorOrDoorway.getMinXMapped(), floorOrDoorway.getMaxYMapped(), floorOrDoorway.getMaxZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
 			final int newColor = boxContains(floorOrDoorway,
 					playerPosition.getXMapped() - HALF_PLAYER_WIDTH,
 					playerPosition.getYMapped(),
@@ -94,13 +90,15 @@ public class RenderVehicleHelper {
 					playerPosition.getYMapped(),
 					playerPosition.getZMapped() + HALF_PLAYER_WIDTH
 			) ? 0xFF00FF00 : color;
-			final Vector3d zeroVector = Vector3d.getZeroMapped();
-			MainRenderer.scheduleRender(QueuedRenderLayer.LINES, (graphicsHolder, offset) -> {
-				drawLine(graphicsHolder, corner1, corner2, useOffset ? offset : zeroVector, newColor);
-				drawLine(graphicsHolder, corner2, corner3, useOffset ? offset : zeroVector, newColor);
-				drawLine(graphicsHolder, corner3, corner4, useOffset ? offset : zeroVector, newColor);
-				drawLine(graphicsHolder, corner4, corner1, useOffset ? offset : zeroVector, newColor);
-			});
+			renderBoxPlane(floorOrDoorway, floorOrDoorway.getMaxYMapped(), newColor, positionAndRotation, useOffset);
+		}
+	}
+
+	public static void renderWeatherCover(Box weatherCoverBox, Vector3d playerPosition, PositionAndRotation positionAndRotation, boolean useOffset) {
+		final ClientPlayerEntity clientPlayerEntity = MinecraftClient.getInstance().getPlayerMapped();
+		if (clientPlayerEntity != null && clientPlayerEntity.isHolding(Items.BRUSH.get())) {
+			final int color = isBelowWeatherCover(weatherCoverBox, playerPosition.getXMapped(), playerPosition.getYMapped(), playerPosition.getZMapped()) ? 0xFF00FF00 : 0xFF00FFFF;
+			renderBoxPlane(weatherCoverBox, weatherCoverBox.getMinYMapped(), color, positionAndRotation, useOffset);
 		}
 	}
 
@@ -122,15 +120,26 @@ public class RenderVehicleHelper {
 	}
 
 	public static boolean isBelowWeatherCover(Box weatherCoverBox, double playerX, double playerY, double playerZ) {
-		return Utilities.isBetween(
-				playerX,
-				weatherCoverBox.getMinXMapped(),
-				weatherCoverBox.getMaxXMapped()
-		) && Utilities.isBetween(
-				playerZ,
-				weatherCoverBox.getMinZMapped(),
-				weatherCoverBox.getMaxZMapped()
-		) && weatherCoverBox.getMinYMapped() >= playerY + WEATHER_COVER_MIN_Y_OFFSET && weatherCoverBox.getMaxYMapped() >= playerY + WEATHER_COVER_HEAD_Y_OFFSET;
+		return playerX + HALF_PLAYER_WIDTH >= weatherCoverBox.getMinXMapped()
+				&& playerX - HALF_PLAYER_WIDTH <= weatherCoverBox.getMaxXMapped()
+				&& playerZ + HALF_PLAYER_WIDTH >= weatherCoverBox.getMinZMapped()
+				&& playerZ - HALF_PLAYER_WIDTH <= weatherCoverBox.getMaxZMapped()
+				&& weatherCoverBox.getMinYMapped() >= playerY + WEATHER_COVER_MIN_Y_OFFSET
+				&& weatherCoverBox.getMaxYMapped() >= playerY + WEATHER_COVER_HEAD_Y_OFFSET;
+	}
+
+	private static void renderBoxPlane(Box box, double y, int color, PositionAndRotation positionAndRotation, boolean useOffset) {
+		final Vector3d corner1 = positionAndRotation.transformForwards(new Vector3d(box.getMinXMapped(), y, box.getMinZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
+		final Vector3d corner2 = positionAndRotation.transformForwards(new Vector3d(box.getMaxXMapped(), y, box.getMinZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
+		final Vector3d corner3 = positionAndRotation.transformForwards(new Vector3d(box.getMaxXMapped(), y, box.getMaxZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
+		final Vector3d corner4 = positionAndRotation.transformForwards(new Vector3d(box.getMinXMapped(), y, box.getMaxZMapped()), Vector3d::rotateX, Vector3d::rotateY, Vector3d::add);
+		final Vector3d zeroVector = Vector3d.getZeroMapped();
+		MainRenderer.scheduleRender(QueuedRenderLayer.LINES, (graphicsHolder, offset) -> {
+			drawLine(graphicsHolder, corner1, corner2, useOffset ? offset : zeroVector, color);
+			drawLine(graphicsHolder, corner2, corner3, useOffset ? offset : zeroVector, color);
+			drawLine(graphicsHolder, corner3, corner4, useOffset ? offset : zeroVector, color);
+			drawLine(graphicsHolder, corner4, corner1, useOffset ? offset : zeroVector, color);
+		});
 	}
 
 	private static void drawLine(GraphicsHolder graphicsHolder, Vector3d corner1, Vector3d corner2, Vector3d offset, int color) {

--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
@@ -190,6 +190,7 @@ public class RenderVehicles implements IGui {
 									gangwayMovementPositions1.check(floor);
 									gangwayMovementPositions2.check(floor);
 								});
+								vehicleResourceCache.weatherCoverBoxes.forEach(weatherCoverBox -> RenderVehicleHelper.renderWeatherCover(weatherCoverBox, playerPosition, vehicleCarRenderingPositionAndRotation, offsetVector == null));
 							}
 
 							openDoorways.forEach(openDoorway -> {

--- a/fabric/src/main/java/org/mtr/mod/resource/ModelPropertiesPart.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/ModelPropertiesPart.java
@@ -118,6 +118,7 @@ public final class ModelPropertiesPart extends ModelPropertiesPartSchema impleme
 			PositionDefinitions positionDefinitionsObject,
 			ObjectArraySet<Box> floors,
 			ObjectArraySet<Box> doorways,
+			ObjectArraySet<Box> weatherCoverBoxes,
 			Object2ObjectOpenHashMap<PartCondition, Object2ObjectOpenHashMap<RenderStage, OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartConditionAndRenderStage,
 			Object2ObjectOpenHashMap<PartCondition, Object2ObjectOpenHashMap<RenderStage, OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsForPartConditionAndRenderStageDoorsClosed
 	) {
@@ -166,6 +167,16 @@ public final class ModelPropertiesPart extends ModelPropertiesPartSchema impleme
 					break;
 				case DOORWAY:
 					iteratePositions(positions, positionsFlipped, (x, y, z, flipped) -> mutableBox.getAll().forEach(box -> doorways.add(addBox(box, x, y, z, flipped))));
+					break;
+				case WEATHER_COVER:
+					iteratePositions(positions, positionsFlipped, (x, y, z, flipped) -> mutableBox.getAll().forEach(box -> weatherCoverBoxes.add(addBox(box, x, y, z, flipped))));
+					break;
+				case WEATHER_COVER_FLOOR:
+					iteratePositions(positions, positionsFlipped, (x, y, z, flipped) -> mutableBox.getAll().forEach(box -> {
+						final Box newBox = addBox(box, x, y, z, flipped);
+						floors.add(newBox);
+						weatherCoverBoxes.add(newBox);
+					}));
 					break;
 			}
 		}));

--- a/fabric/src/main/java/org/mtr/mod/resource/PartType.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/PartType.java
@@ -1,3 +1,3 @@
 package org.mtr.mod.resource;
 
-public enum PartType {NORMAL, DISPLAY, FLOOR, DOORWAY, SEAT}
+public enum PartType {NORMAL, DISPLAY, FLOOR, DOORWAY, WEATHER_COVER, WEATHER_COVER_FLOOR, SEAT}

--- a/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
@@ -34,7 +34,7 @@ public interface StoredModelResourceBase {
 					new PositionDefinitions(),
 					""
 			);
-			tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
+			tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
 			models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromMaterialGroups(materialGroups.get(PartCondition.NORMAL)), tempDynamicVehicleModel);
 		} else if (isSupportedModelResource) {
 			try {
@@ -48,7 +48,7 @@ public interface StoredModelResourceBase {
 						new PositionDefinitions(),
 						""
 				);
-				dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
+				dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
 				models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
 			} catch (Exception e) {
 				Init.LOGGER.error("[{}] Invalid model!", modelResource, e);

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleResource.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleResource.java
@@ -210,7 +210,7 @@ public final class VehicleResource extends VehicleResourceSchema {
 					final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsBogie1 = data3.optimizedModelsBogie1.getData(force);
 					final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsBogie2 = data3.optimizedModelsBogie2.getData(force);
 					if (optimizedModels != null && optimizedModelsDoorsClosed != null && optimizedModelsBogie1 != null && optimizedModelsBogie2 != null) {
-						return new VehicleResourceCache(data3.floors, data3.doorways, optimizedModels, optimizedModelsDoorsClosed, optimizedModelsBogie1, optimizedModelsBogie2);
+						return new VehicleResourceCache(data3.floors, data3.doorways, data3.weatherCoverBoxes, optimizedModels, optimizedModelsDoorsClosed, optimizedModelsBogie1, optimizedModelsBogie2);
 					}
 				}
 			}
@@ -425,6 +425,7 @@ public final class VehicleResource extends VehicleResourceSchema {
 				}
 
 				final ObjectArrayList<Box> floors = new ObjectArrayList<>();
+				final ObjectArrayList<Box> weatherCoverBoxes = new ObjectArrayList<>();
 				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsModel = new Object2ObjectOpenHashMap<>();
 				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsModelDoorsClosed = new Object2ObjectOpenHashMap<>();
 				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroupsBogie1Model = new Object2ObjectOpenHashMap<>();
@@ -435,7 +436,7 @@ public final class VehicleResource extends VehicleResourceSchema {
 				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModelsBogie2Model = new Object2ObjectOpenHashMap<>();
 
 				final ObjectArrayList<Box> doorways = new ObjectArrayList<>();
-				forEachNonNull(allModelsList, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(floors, doorways, materialGroupsModel, materialGroupsModelDoorsClosed, objModelsModel, objModelsModelDoorsClosed), force);
+				forEachNonNull(allModelsList, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(floors, doorways, weatherCoverBoxes, materialGroupsModel, materialGroupsModelDoorsClosed, objModelsModel, objModelsModelDoorsClosed), force);
 
 				if (floors.isEmpty() && doorways.isEmpty()) {
 					Init.LOGGER.info("[{}] No floors or doorways found in vehicle models", id);
@@ -451,15 +452,15 @@ public final class VehicleResource extends VehicleResourceSchema {
 				}
 
 				forEachNonNull(allModelsList, dynamicVehicleModel -> dynamicVehicleModel.modelProperties.iterateParts(modelPropertiesPart -> modelPropertiesPart.mapDoors(doorways)), force);
-				forEachNonNull(bogie1Models, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroupsBogie1Model, new Object2ObjectOpenHashMap<>(), objModelsBogie1Model), force);
-				forEachNonNull(bogie2Models, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroupsBogie2Model, new Object2ObjectOpenHashMap<>(), objModelsBogie2Model), force);
+				forEachNonNull(bogie1Models, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroupsBogie1Model, new Object2ObjectOpenHashMap<>(), objModelsBogie1Model), force);
+				forEachNonNull(bogie2Models, dynamicVehicleModel -> dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroupsBogie2Model, new Object2ObjectOpenHashMap<>(), objModelsBogie2Model), force);
 
 				return new CachedResource<>(() -> {
 					final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModels = writeToOptimizedModels(materialGroupsModel, objModelsModel, modelLifespan);
 					final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsDoorsClosed = writeToOptimizedModels(materialGroupsModelDoorsClosed, objModelsModelDoorsClosed, modelLifespan);
 					final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsBogie1 = writeToOptimizedModels(materialGroupsBogie1Model, objModelsBogie1Model, modelLifespan);
 					final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsBogie2 = writeToOptimizedModels(materialGroupsBogie2Model, objModelsBogie2Model, modelLifespan);
-					return new VehicleResourceCacheHolder(new ObjectImmutableList<>(floors), new ObjectImmutableList<>(doorways), optimizedModels, optimizedModelsDoorsClosed, optimizedModelsBogie1, optimizedModelsBogie2);
+					return new VehicleResourceCacheHolder(new ObjectImmutableList<>(floors), new ObjectImmutableList<>(doorways), new ObjectImmutableList<>(weatherCoverBoxes), optimizedModels, optimizedModelsDoorsClosed, optimizedModelsBogie1, optimizedModelsBogie2);
 				}, modelLifespan);
 			}, modelLifespan);
 		}, modelLifespan);
@@ -565,13 +566,14 @@ public final class VehicleResource extends VehicleResourceSchema {
 
 		private final ObjectImmutableList<Box> floors;
 		private final ObjectImmutableList<Box> doorways;
+		private final ObjectImmutableList<Box> weatherCoverBoxes;
 		private final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModels;
 		private final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsDoorsClosed;
 		private final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsBogie1;
 		private final CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsBogie2;
 
 		private VehicleResourceCacheHolder(
-				ObjectImmutableList<Box> floors, ObjectImmutableList<Box> doorways,
+				ObjectImmutableList<Box> floors, ObjectImmutableList<Box> doorways, ObjectImmutableList<Box> weatherCoverBoxes,
 				CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModels,
 				CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsDoorsClosed,
 				CachedResource<Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper>> optimizedModelsBogie1,
@@ -579,6 +581,7 @@ public final class VehicleResource extends VehicleResourceSchema {
 		) {
 			this.floors = floors;
 			this.doorways = doorways;
+			this.weatherCoverBoxes = weatherCoverBoxes;
 			this.optimizedModels = optimizedModels;
 			this.optimizedModelsDoorsClosed = optimizedModelsDoorsClosed;
 			this.optimizedModelsBogie1 = optimizedModelsBogie1;

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleResourceCache.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleResourceCache.java
@@ -8,6 +8,7 @@ public final class VehicleResourceCache {
 
 	public final ObjectImmutableList<Box> floors;
 	public final ObjectImmutableList<Box> doorways;
+	public final ObjectImmutableList<Box> weatherCoverBoxes;
 	public final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModels;
 	public final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsDoorsClosed;
 	public final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsBogie1;
@@ -16,6 +17,7 @@ public final class VehicleResourceCache {
 	public VehicleResourceCache(
 			ObjectImmutableList<Box> floors,
 			ObjectImmutableList<Box> doorways,
+			ObjectImmutableList<Box> weatherCoverBoxes,
 			Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModels,
 			Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsDoorsClosed,
 			Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModelsBogie1,
@@ -23,6 +25,7 @@ public final class VehicleResourceCache {
 	) {
 		this.floors = floors;
 		this.doorways = doorways;
+		this.weatherCoverBoxes = weatherCoverBoxes;
 		this.optimizedModels = optimizedModels;
 		this.optimizedModelsDoorsClosed = optimizedModelsDoorsClosed;
 		this.optimizedModelsBogie1 = optimizedModelsBogie1;

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a320.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a320.json
@@ -213,6 +213,95 @@
 				"main"
 			],
 			"type": "DOORWAY"
+		},
+		{
+			"names": [
+				"exterior/main/roof",
+				"exterior/left_engine/roof",
+				"exterior/right_engine/roof"
+			],
+			"positionDefinitions": [
+				"main"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_interior/roof",
+				"head_interior/roof_front",
+				"end_interior/roof"
+			],
+			"positionDefinitions": [
+				"main"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_interior_blank/roof_side",
+				"window_interior_blank/roof"
+			],
+			"positionDefinitions": [
+				"front"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_interior/roof_side",
+				"window_interior/roof"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"exterior/main/left_roof",
+				"exterior/main/right_roof",
+				"exterior/tail/left_roof_top",
+				"exterior/tail/right_roof_top",
+				"exterior/left_engine/left_roof",
+				"exterior/left_engine/right_roof",
+				"exterior/left_engine/front_roof",
+				"exterior/left_engine/front_left_roof",
+				"exterior/left_engine/front_right_roof",
+				"exterior/left_engine/back_roof",
+				"exterior/left_engine/back_left_roof",
+				"exterior/left_engine/back_right_roof",
+				"exterior/left_engine/tail_roof",
+				"exterior/left_engine/tail_left_roof",
+				"exterior/left_engine/tail_right_roof",
+				"exterior/right_engine/left_roof",
+				"exterior/right_engine/right_roof",
+				"exterior/right_engine/front_roof",
+				"exterior/right_engine/front_left_roof",
+				"exterior/right_engine/front_right_roof",
+				"exterior/right_engine/back_roof",
+				"exterior/right_engine/back_left_roof",
+				"exterior/right_engine/back_right_roof",
+				"exterior/right_engine/tail_roof",
+				"exterior/right_engine/tail_left_roof",
+				"exterior/right_engine/tail_right_roof"
+			],
+			"positionDefinitions": [
+				"main"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_interior/left_roof_side",
+				"head_interior/right_roof_side",
+				"end_interior/left_roof_side",
+				"end_interior/right_roof_side"
+			],
+			"positionDefinitions": [
+				"main"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 3.5

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_common.json
@@ -281,6 +281,39 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_ael"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowEnd1",
+				"windowEnd1Flipped",
+				"windowEnd2",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"doorRoof"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_ael"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_common.json
@@ -314,6 +314,29 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_window_ael"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowEnd1",
+				"windowEnd1Flipped",
+				"windowEnd2",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_door_ael"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_end_1.json
@@ -48,6 +48,25 @@
 				"seatEnd1"
 			],
 			"renderStage": "INTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowEnd1",
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_end_2.json
@@ -48,6 +48,25 @@
 				"seatEnd2"
 			],
 			"renderStage": "INTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowEnd2",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_1.json
@@ -110,6 +110,20 @@
 				"end1Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_1.json
@@ -92,6 +92,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end1Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_2.json
@@ -92,6 +92,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end2Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_ael_head_2.json
@@ -110,6 +110,20 @@
 				"end2Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_common.json
@@ -324,6 +324,22 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_tcl"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_common.json
@@ -280,6 +280,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_tcl"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_tcl"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_1.json
@@ -105,6 +105,24 @@
 			"doorXMultiplier": -1,
 			"doorZMultiplier": -14,
 			"doorAnimationType": "PLUG_FAST"
+		},
+		{
+			"names": [
+				"roof_end_tcl"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_1.json
@@ -123,6 +123,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_tcl"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_2.json
@@ -123,6 +123,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_tcl"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_end_2.json
@@ -105,6 +105,24 @@
 			"doorXMultiplier": -1,
 			"doorZMultiplier": -14,
 			"doorAnimationType": "PLUG_FAST"
+		},
+		{
+			"names": [
+				"roof_end_tcl"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_1.json
@@ -159,6 +159,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_tcl"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_1.json
@@ -177,6 +177,29 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_tcl"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_2.json
@@ -177,6 +177,29 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_tcl"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/a_train_tcl_head_2.json
@@ -159,6 +159,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_tcl"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/boat_small.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/boat_small.json
@@ -60,6 +60,15 @@
 				"main"
 			],
 			"type": "DOORWAY"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"extra"
+			],
+			"type": "WEATHER_COVER"
 		}
 	]
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_common.json
@@ -402,6 +402,70 @@
 				"CYCLE_LANGUAGES"
 			],
 			"displayType": "ROUTE_NUMBER"
+		},
+		{
+			"names": [
+				"roof_window_interior"
+			],
+			"positionDefinitions": [
+				"window2",
+				"window2Flipped",
+				"window3",
+				"window3Flipped",
+				"window4",
+				"window4Flipped",
+				"window5",
+				"window5Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window_exterior_1"
+			],
+			"positionDefinitions": [
+				"window1Flipped",
+				"window2",
+				"window3Flipped",
+				"window4",
+				"window5Flipped",
+				"window6"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window_exterior_2"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window2Flipped",
+				"window3",
+				"window4Flipped",
+				"window5",
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_interior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_1.json
@@ -67,6 +67,19 @@
 				"window1Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_1",
+				"end_exterior/end_exterior_left/roof_2",
+				"end_exterior/end_exterior_right/roof_2",
+				"end_exterior/end_exterior_right/roof_3",
+				"end_exterior/roof_3"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_1.json
@@ -57,6 +57,16 @@
 				"end1Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_interior"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_2.json
@@ -67,6 +67,19 @@
 				"window6Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_1",
+				"end_exterior/end_exterior_left/roof_2",
+				"end_exterior/end_exterior_right/roof_2",
+				"end_exterior/end_exterior_right/roof_3",
+				"end_exterior/roof_3"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_end_2.json
@@ -57,6 +57,16 @@
 				"end2Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_interior"
+			],
+			"positionDefinitions": [
+				"window6",
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_head_1.json
@@ -120,6 +120,53 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"light_head/roof_left",
+				"light_head/roof_right",
+				"light_head/roof"
+			],
+			"positionDefinitions": [
+				"window1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_interior/head_interior_left/roof_2",
+				"head_interior/head_interior_right/roof_2",
+				"head_interior/roof"
+			],
+			"positionDefinitions": [
+				"window1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/roof_1",
+				"head_exterior/head_exterior_left/roof_2",
+				"head_exterior/head_exterior_right/roof_1",
+				"head_exterior/head_exterior_right/roof_2",
+				"head_exterior/roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/side_roof_1",
+				"head_exterior/head_exterior_left/side_roof_2",
+				"head_exterior/head_exterior_right/side_roof_1",
+				"head_exterior/head_exterior_right/side_roof_2"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/br_423_head_2.json
@@ -120,6 +120,53 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"light_head/roof_left",
+				"light_head/roof_right",
+				"light_head/roof"
+			],
+			"positionDefinitions": [
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_interior/head_interior_left/roof_2",
+				"head_interior/head_interior_right/roof_2",
+				"head_interior/roof"
+			],
+			"positionDefinitions": [
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/roof_1",
+				"head_exterior/head_exterior_left/roof_2",
+				"head_exterior/head_exterior_right/roof_1",
+				"head_exterior/head_exterior_right/roof_2",
+				"head_exterior/roof_3"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/side_roof_1",
+				"head_exterior/head_exterior_left/side_roof_2",
+				"head_exterior/head_exterior_right/side_roof_1",
+				"head_exterior/head_exterior_right/side_roof_2"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_common.json
@@ -257,6 +257,46 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_c1141a"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_c1141a"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_common.json
@@ -297,6 +297,18 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_c1141a"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_1.json
@@ -65,6 +65,25 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_c1141a"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/outer_roof_1",
+				"end_exterior/outer_roof_2"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_1.json
@@ -47,6 +47,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_c1141a"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_2.json
@@ -65,6 +65,25 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_c1141a"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/outer_roof_1",
+				"end_exterior/outer_roof_2"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_end_2.json
@@ -47,6 +47,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_c1141a"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_1.json
@@ -126,6 +126,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_c1141a"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"roofHead1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_1.json
@@ -144,6 +144,41 @@
 				"roofHead1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_c1141a"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/roof_corner_2_r1",
+				"head_exterior/front/roof_corner_1_r1",
+				"head_exterior/front/roof_middle_corner_2_r1",
+				"head_exterior/front/roof_middle_corner_1_r1",
+				"head_exterior/front/roof_side_2_r1",
+				"head_exterior/front/roof_side_1_r1"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_roof",
+				"head_exterior/outer_roof_2",
+				"head_exterior/outer_roof_1",
+				"head_exterior/front/front_roof_r1"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_2.json
@@ -126,6 +126,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_c1141a"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"roofHead2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c1141a_head_2.json
@@ -144,6 +144,41 @@
 				"roofHead2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_c1141a"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/roof_corner_2_r1",
+				"head_exterior/front/roof_corner_1_r1",
+				"head_exterior/front/roof_middle_corner_2_r1",
+				"head_exterior/front/roof_middle_corner_1_r1",
+				"head_exterior/front/roof_side_2_r1",
+				"head_exterior/front/roof_side_1_r1"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_roof",
+				"head_exterior/outer_roof_2",
+				"head_exterior/outer_roof_1",
+				"head_exterior/front/front_roof_r1"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_common.json
@@ -340,6 +340,22 @@
 				"doorEnd2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_common.json
@@ -292,6 +292,54 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_1.json
@@ -37,6 +37,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_1.json
@@ -55,6 +55,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_2.json
@@ -55,6 +55,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_end_2.json
@@ -37,6 +37,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_1.json
@@ -113,6 +113,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_1.json
@@ -131,6 +131,31 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_2.json
@@ -113,6 +113,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/c_train_head_2.json
@@ -131,6 +131,31 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_1_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_1_trailer.json
@@ -289,6 +289,122 @@
 				"2d146e26"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"5b521719"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/side_1/roof",
+				"door/side_2/roof",
+				"door/roof",
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"f73303f9"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1_exterior/window_exterior_1_left/roof_1",
+				"window_1_exterior/window_exterior_1_left/roof_2",
+				"window_1_exterior/window_exterior_1_left/roof_3",
+				"window_1_exterior/window_exterior_1_left/roof_4",
+				"window_1_exterior/window_exterior_1_left_end/roof_1",
+				"window_1_exterior/window_exterior_1_left_end/roof_2",
+				"window_1_exterior/window_exterior_1_left_end/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_1",
+				"window_1_exterior/window_exterior_1_right/roof_2",
+				"window_1_exterior/window_exterior_1_right/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_4",
+				"window_1_exterior/window_exterior_1_right_end/roof_1",
+				"window_1_exterior/window_exterior_1_right_end/roof_2",
+				"window_1_exterior/window_exterior_1_right_end/roof_3"
+			],
+			"positionDefinitions": [
+				"4e762bee"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2_exterior/window_exterior_2_left/roof_2",
+				"window_2_exterior/window_exterior_2_left/roof_3",
+				"window_2_exterior/window_exterior_2_left/roof_4",
+				"window_2_exterior/window_exterior_2_left/roof_5",
+				"window_2_exterior/window_exterior_2_right/roof_2",
+				"window_2_exterior/window_exterior_2_right/roof_3",
+				"window_2_exterior/window_exterior_2_right/roof_4",
+				"window_2_exterior/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"1b2b647a"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left/roof"
+			],
+			"positionDefinitions": [
+				"c28ef401"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/roof"
+			],
+			"positionDefinitions": [
+				"3d70bc63"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left_exterior/roof"
+			],
+			"positionDefinitions": [
+				"fb0d1bc6"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right_exterior/roof"
+			],
+			"positionDefinitions": [
+				"6b9dec2a"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_left/roof_2",
+				"end/end_left/roof_4",
+				"end/end_left/roof_5",
+				"end/end_left/roof_6",
+				"end/end_right/roof_2",
+				"end/end_right/roof_4",
+				"end/end_right/roof_5",
+				"end/end_right/roof_6"
+			],
+			"positionDefinitions": [
+				"d530f4cd"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_1_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_1_trailer.json
@@ -71,8 +71,8 @@
 				"c28ef401"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -83,8 +83,8 @@
 				"3d70bc63"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -95,8 +95,8 @@
 				"fb0d1bc6"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -107,8 +107,8 @@
 				"6b9dec2a"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -210,7 +210,7 @@
 				"c01b90e7"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
+			"displayXPadding": 1,
 			"displayYPadding": 0.5,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
@@ -280,9 +280,18 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "FLOOR"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"2d146e26"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/k_train_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/k_train_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/k_train_floor.png",
@@ -290,7 +299,7 @@
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayWidth": 1.5,
-	"gangwayHeight": 2.0,
-	"gangwayYOffset": 1.0,
+	"gangwayHeight": 2,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_2_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_2_trailer.json
@@ -71,8 +71,8 @@
 				"4e58d077"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -83,8 +83,8 @@
 				"781c5151"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -95,8 +95,8 @@
 				"d258ae92"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -107,8 +107,8 @@
 				"921e1496"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -201,7 +201,7 @@
 				"d6801571"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
+			"displayXPadding": 1,
 			"displayYPadding": 0.5,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
@@ -261,9 +261,18 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "FLOOR"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"fd66ba1a"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/k_train_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/k_train_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/k_train_floor.png",
@@ -271,7 +280,7 @@
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayWidth": 1.5,
-	"gangwayHeight": 2.0,
-	"gangwayYOffset": 1.0,
+	"gangwayHeight": 2,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_2_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_2_trailer.json
@@ -270,6 +270,122 @@
 				"fd66ba1a"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"16e69fcc"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/side_1/roof",
+				"door/side_2/roof",
+				"door/roof",
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"b6d2b21a"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1_exterior/window_exterior_1_left/roof_1",
+				"window_1_exterior/window_exterior_1_left/roof_2",
+				"window_1_exterior/window_exterior_1_left/roof_3",
+				"window_1_exterior/window_exterior_1_left/roof_4",
+				"window_1_exterior/window_exterior_1_left_end/roof_1",
+				"window_1_exterior/window_exterior_1_left_end/roof_2",
+				"window_1_exterior/window_exterior_1_left_end/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_1",
+				"window_1_exterior/window_exterior_1_right/roof_2",
+				"window_1_exterior/window_exterior_1_right/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_4",
+				"window_1_exterior/window_exterior_1_right_end/roof_1",
+				"window_1_exterior/window_exterior_1_right_end/roof_2",
+				"window_1_exterior/window_exterior_1_right_end/roof_3"
+			],
+			"positionDefinitions": [
+				"131a41c1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2_exterior/window_exterior_2_left/roof_2",
+				"window_2_exterior/window_exterior_2_left/roof_3",
+				"window_2_exterior/window_exterior_2_left/roof_4",
+				"window_2_exterior/window_exterior_2_left/roof_5",
+				"window_2_exterior/window_exterior_2_right/roof_2",
+				"window_2_exterior/window_exterior_2_right/roof_3",
+				"window_2_exterior/window_exterior_2_right/roof_4",
+				"window_2_exterior/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"7d725a6c"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left/roof"
+			],
+			"positionDefinitions": [
+				"4e58d077"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/roof"
+			],
+			"positionDefinitions": [
+				"781c5151"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left_exterior/roof"
+			],
+			"positionDefinitions": [
+				"d258ae92"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right_exterior/roof"
+			],
+			"positionDefinitions": [
+				"921e1496"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_left/roof_2",
+				"end/end_left/roof_4",
+				"end/end_left/roof_5",
+				"end/end_left/roof_6",
+				"end/end_right/roof_2",
+				"end/end_right/roof_4",
+				"end/end_right/roof_5",
+				"end/end_right/roof_6"
+			],
+			"positionDefinitions": [
+				"36647e8c"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_1.json
@@ -346,6 +346,138 @@
 				"a95afc2b"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"c2357fe8"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/side_1/roof",
+				"door/side_2/roof",
+				"door/roof",
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"35ca377b"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1_exterior/window_exterior_1_left/roof_1",
+				"window_1_exterior/window_exterior_1_left/roof_2",
+				"window_1_exterior/window_exterior_1_left/roof_3",
+				"window_1_exterior/window_exterior_1_left/roof_4",
+				"window_1_exterior/window_exterior_1_left_end/roof_1",
+				"window_1_exterior/window_exterior_1_left_end/roof_2",
+				"window_1_exterior/window_exterior_1_left_end/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_1",
+				"window_1_exterior/window_exterior_1_right/roof_2",
+				"window_1_exterior/window_exterior_1_right/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_4",
+				"window_1_exterior/window_exterior_1_right_end/roof_1",
+				"window_1_exterior/window_exterior_1_right_end/roof_2",
+				"window_1_exterior/window_exterior_1_right_end/roof_3"
+			],
+			"positionDefinitions": [
+				"74cb5204"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2_exterior/window_exterior_2_left/roof_2",
+				"window_2_exterior/window_exterior_2_left/roof_3",
+				"window_2_exterior/window_exterior_2_left/roof_4",
+				"window_2_exterior/window_exterior_2_left/roof_5",
+				"window_2_exterior/window_exterior_2_right/roof_2",
+				"window_2_exterior/window_exterior_2_right/roof_3",
+				"window_2_exterior/window_exterior_2_right/roof_4",
+				"window_2_exterior/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"979fca95"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left/roof"
+			],
+			"positionDefinitions": [
+				"a8374e48"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/roof"
+			],
+			"positionDefinitions": [
+				"3c1c2f2d"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left_exterior/roof"
+			],
+			"positionDefinitions": [
+				"8ec819a6"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right_exterior/roof"
+			],
+			"positionDefinitions": [
+				"a4089846"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_left/roof_2",
+				"end/end_left/roof_4",
+				"end/end_left/roof_5",
+				"end/end_left/roof_6",
+				"end/end_right/roof_2",
+				"end/end_right/roof_4",
+				"end/end_right/roof_5",
+				"end/end_right/roof_6"
+			],
+			"positionDefinitions": [
+				"a12d6fa2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/roof_2",
+				"head_exterior/head_exterior_left/roof_3",
+				"head_exterior/head_exterior_left/roof_4",
+				"head_exterior/head_exterior_left/roof_5",
+				"head_exterior/head_exterior_right/roof_2",
+				"head_exterior/head_exterior_right/roof_3",
+				"head_exterior/head_exterior_right/roof_4",
+				"head_exterior/head_exterior_right/roof_5"
+			],
+			"positionDefinitions": [
+				"6c1b8698"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_1.json
@@ -71,8 +71,8 @@
 				"a8374e48"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -83,8 +83,8 @@
 				"3c1c2f2d"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -95,8 +95,8 @@
 				"8ec819a6"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -107,8 +107,8 @@
 				"a4089846"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -228,7 +228,7 @@
 				"99d88bec"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
+			"displayXPadding": 1,
 			"displayYPadding": 0.5,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
@@ -247,8 +247,8 @@
 				"cd81a58c"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
-			"displayYPadding": 1.0,
+			"displayXPadding": 1,
+			"displayYPadding": 1,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayOptions": [
@@ -337,9 +337,18 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"a95afc2b"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/k_train_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/k_train_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/k_train_floor.png",
@@ -347,7 +356,7 @@
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayWidth": 1.5,
-	"gangwayHeight": 2.0,
-	"gangwayYOffset": 1.0,
+	"gangwayHeight": 2,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_2.json
@@ -71,8 +71,8 @@
 				"7d00cdd8"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -83,8 +83,8 @@
 				"d4729650"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -95,8 +95,8 @@
 				"d7796ea2"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -107,8 +107,8 @@
 				"d90d77e1"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -228,7 +228,7 @@
 				"838af83b"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
+			"displayXPadding": 1,
 			"displayYPadding": 0.5,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
@@ -247,8 +247,8 @@
 				"67d6285f"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
-			"displayYPadding": 1.0,
+			"displayXPadding": 1,
+			"displayYPadding": 1,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayOptions": [
@@ -337,9 +337,18 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"93ce1004"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/k_train_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/k_train_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/k_train_floor.png",
@@ -347,7 +356,7 @@
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayWidth": 1.5,
-	"gangwayHeight": 2.0,
-	"gangwayYOffset": 1.0,
+	"gangwayHeight": 2,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_2.json
@@ -346,6 +346,138 @@
 				"93ce1004"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"98b1ad3c"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/side_1/roof",
+				"door/side_2/roof",
+				"door/roof",
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"4c7e2842"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1_exterior/window_exterior_1_left/roof_1",
+				"window_1_exterior/window_exterior_1_left/roof_2",
+				"window_1_exterior/window_exterior_1_left/roof_3",
+				"window_1_exterior/window_exterior_1_left/roof_4",
+				"window_1_exterior/window_exterior_1_left_end/roof_1",
+				"window_1_exterior/window_exterior_1_left_end/roof_2",
+				"window_1_exterior/window_exterior_1_left_end/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_1",
+				"window_1_exterior/window_exterior_1_right/roof_2",
+				"window_1_exterior/window_exterior_1_right/roof_3",
+				"window_1_exterior/window_exterior_1_right/roof_4",
+				"window_1_exterior/window_exterior_1_right_end/roof_1",
+				"window_1_exterior/window_exterior_1_right_end/roof_2",
+				"window_1_exterior/window_exterior_1_right_end/roof_3"
+			],
+			"positionDefinitions": [
+				"40a13ae5"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2_exterior/window_exterior_2_left/roof_2",
+				"window_2_exterior/window_exterior_2_left/roof_3",
+				"window_2_exterior/window_exterior_2_left/roof_4",
+				"window_2_exterior/window_exterior_2_left/roof_5",
+				"window_2_exterior/window_exterior_2_right/roof_2",
+				"window_2_exterior/window_exterior_2_right/roof_3",
+				"window_2_exterior/window_exterior_2_right/roof_4",
+				"window_2_exterior/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"35211177"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left/roof"
+			],
+			"positionDefinitions": [
+				"7d00cdd8"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/roof"
+			],
+			"positionDefinitions": [
+				"d4729650"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left_exterior/roof"
+			],
+			"positionDefinitions": [
+				"d7796ea2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right_exterior/roof"
+			],
+			"positionDefinitions": [
+				"d90d77e1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_left/roof_2",
+				"end/end_left/roof_4",
+				"end/end_left/roof_5",
+				"end/end_left/roof_6",
+				"end/end_right/roof_2",
+				"end/end_right/roof_4",
+				"end/end_right/roof_5",
+				"end/end_right/roof_6"
+			],
+			"positionDefinitions": [
+				"6b8aff19"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/roof_2",
+				"head_exterior/head_exterior_left/roof_3",
+				"head_exterior/head_exterior_left/roof_4",
+				"head_exterior/head_exterior_left/roof_5",
+				"head_exterior/head_exterior_right/roof_2",
+				"head_exterior/head_exterior_right/roof_3",
+				"head_exterior/head_exterior_right/roof_4",
+				"head_exterior/head_exterior_right/roof_5"
+			],
+			"positionDefinitions": [
+				"adfc3852"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_3.json
@@ -329,6 +329,100 @@
 				"3b86dce4"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"35f0eadc"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/side_1/roof",
+				"door/side_2/roof",
+				"door/roof",
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"2af6fe53"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2_exterior/window_exterior_2_left/roof_2",
+				"window_2_exterior/window_exterior_2_left/roof_3",
+				"window_2_exterior/window_exterior_2_left/roof_4",
+				"window_2_exterior/window_exterior_2_left/roof_5",
+				"window_2_exterior/window_exterior_2_right/roof_2",
+				"window_2_exterior/window_exterior_2_right/roof_3",
+				"window_2_exterior/window_exterior_2_right/roof_4",
+				"window_2_exterior/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"fd8ab1d7"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left/roof"
+			],
+			"positionDefinitions": [
+				"4a930052"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/roof"
+			],
+			"positionDefinitions": [
+				"d2cc4072"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_left_exterior/roof"
+			],
+			"positionDefinitions": [
+				"54692104"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right_exterior/roof"
+			],
+			"positionDefinitions": [
+				"62ccb409"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_left/roof_2",
+				"head_exterior/head_exterior_left/roof_3",
+				"head_exterior/head_exterior_left/roof_4",
+				"head_exterior/head_exterior_left/roof_5",
+				"head_exterior/head_exterior_right/roof_2",
+				"head_exterior/head_exterior_right/roof_3",
+				"head_exterior/head_exterior_right/roof_4",
+				"head_exterior/head_exterior_right/roof_5"
+			],
+			"positionDefinitions": [
+				"c5af371b"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_345_cab_3.json
@@ -62,8 +62,8 @@
 				"4a930052"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -74,8 +74,8 @@
 				"d2cc4072"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -86,8 +86,8 @@
 				"54692104"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": 12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": 12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -98,8 +98,8 @@
 				"62ccb409"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
-			"doorZMultiplier": -12.0,
+			"doorXMultiplier": -1,
+			"doorZMultiplier": -12,
 			"doorAnimationType": "PLUG_FAST"
 		},
 		{
@@ -201,7 +201,7 @@
 				"b801b276"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
+			"displayXPadding": 1,
 			"displayYPadding": 0.5,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
@@ -220,8 +220,8 @@
 				"a86f1e4"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 1.0,
-			"displayYPadding": 1.0,
+			"displayXPadding": 1,
+			"displayYPadding": 1,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayOptions": [
@@ -320,11 +320,20 @@
 			],
 			"condition": "ON_ROUTE_BACKWARDS",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"3b86dce4"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayWidth": 1.5,
-	"gangwayHeight": 2.0,
-	"gangwayYOffset": 1.0,
+	"gangwayHeight": 2,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_common.json
@@ -290,6 +290,44 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_exterior_1"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window4",
+				"window4Flipped",
+				"window5",
+				"window5Flipped",
+				"window8",
+				"window8Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door_edge"
+			],
+			"positionDefinitions": [
+				"window2",
+				"window3Flipped",
+				"window6",
+				"window7Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"door1",
+				"door2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_common.json
@@ -328,6 +328,45 @@
 				"door2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_2",
+				"window/roof_3"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window2Flipped",
+				"window3",
+				"window3Flipped",
+				"window4",
+				"window4Flipped",
+				"window5",
+				"window5Flipped",
+				"window6",
+				"window6Flipped",
+				"window7",
+				"window7Flipped",
+				"window8",
+				"window8Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_3",
+				"door/roof_4"
+			],
+			"positionDefinitions": [
+				"door1",
+				"door1Flipped",
+				"door2",
+				"door2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_end_1.json
@@ -155,6 +155,22 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior_1/roof_1",
+				"end_exterior/roof_end_exterior_1/roof_2",
+				"end_exterior/roof_end_exterior_1/roof_3",
+				"end_exterior/roof_end_exterior_1/roof_4",
+				"end_exterior/roof_end_exterior_2/roof_2",
+				"end_exterior/roof_end_exterior_2/roof_3",
+				"end_exterior/roof_end_exterior_2/roof_4",
+				"end_exterior/roof_end_exterior_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_end_2.json
@@ -155,6 +155,22 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior_1/roof_1",
+				"end_exterior/roof_end_exterior_1/roof_2",
+				"end_exterior/roof_end_exterior_1/roof_3",
+				"end_exterior/roof_end_exterior_1/roof_4",
+				"end_exterior/roof_end_exterior_2/roof_2",
+				"end_exterior/roof_end_exterior_2/roof_3",
+				"end_exterior/roof_end_exterior_2/roof_4",
+				"end_exterior/roof_end_exterior_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_head_1.json
@@ -197,6 +197,22 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_1/roof_2",
+				"head_exterior/head_exterior_1/roof_3",
+				"head_exterior/head_exterior_1/roof_4",
+				"head_exterior/head_exterior_1/roof_5",
+				"head_exterior/head_exterior_2/roof_3",
+				"head_exterior/head_exterior_2/roof_4",
+				"head_exterior/head_exterior_2/roof_5",
+				"head_exterior/head_exterior_2/roof_6"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_377_head_2.json
@@ -197,6 +197,22 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_1/roof_2",
+				"head_exterior/head_exterior_1/roof_3",
+				"head_exterior/head_exterior_1/roof_4",
+				"head_exterior/head_exterior_1/roof_5",
+				"head_exterior/head_exterior_2/roof_3",
+				"head_exterior/head_exterior_2/roof_4",
+				"head_exterior/head_exterior_2/roof_5",
+				"head_exterior/head_exterior_2/roof_6"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_common.json
@@ -120,6 +120,20 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window4",
+				"window4Flipped",
+				"window5",
+				"window5Flipped",
+				"window6",
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_common.json
@@ -134,6 +134,23 @@
 				"window6Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_2",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"window4",
+				"window4Flipped",
+				"window5",
+				"window5Flipped",
+				"window6",
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_1.json
@@ -199,6 +199,75 @@
 				"end1Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_2",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window2Flipped",
+				"window3",
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_light/roof_5"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_1/roof_1",
+				"end/end_side_1/roof_2",
+				"end/end_side_1/roof_3",
+				"end/end_side_1/roof_4",
+				"end/end_side_2/roof",
+				"end/end_side_2/roof_2",
+				"end/end_side_2/roof_3",
+				"end/end_side_2/roof_4",
+				"end/end_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_side_1/roof_1",
+				"end_exterior/end_exterior_side_1/roof_2",
+				"end_exterior/end_exterior_side_1/roof_3",
+				"end_exterior/end_exterior_side_1/roof_4",
+				"end_exterior/end_exterior_side_2/roof_2",
+				"end_exterior/end_exterior_side_2/roof_3",
+				"end_exterior/end_exterior_side_2/roof_4",
+				"end_exterior/end_exterior_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_1.json
@@ -182,6 +182,23 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window2Flipped",
+				"window3",
+				"window3Flipped",
+				"roofEnd1",
+				"end1",
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_2.json
@@ -199,6 +199,75 @@
 				"end2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_2",
+				"window/roof_3",
+				"window/roof_4"
+			],
+			"positionDefinitions": [
+				"window7",
+				"window7Flipped",
+				"window8",
+				"window8Flipped",
+				"window9",
+				"window9Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_light/roof_5"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_1/roof_1",
+				"end/end_side_1/roof_2",
+				"end/end_side_1/roof_3",
+				"end/end_side_1/roof_4",
+				"end/end_side_2/roof",
+				"end/end_side_2/roof_2",
+				"end/end_side_2/roof_3",
+				"end/end_side_2/roof_4",
+				"end/end_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_side_1/roof_1",
+				"end_exterior/end_exterior_side_1/roof_2",
+				"end_exterior/end_exterior_side_1/roof_3",
+				"end_exterior/end_exterior_side_1/roof_4",
+				"end_exterior/end_exterior_side_2/roof_2",
+				"end_exterior/end_exterior_side_2/roof_3",
+				"end_exterior/end_exterior_side_2/roof_4",
+				"end_exterior/end_exterior_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_end_2.json
@@ -182,6 +182,23 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window7",
+				"window7Flipped",
+				"window8",
+				"window8Flipped",
+				"window9",
+				"window9Flipped",
+				"roofEnd2",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_1.json
@@ -164,6 +164,18 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window2",
+				"window2Flipped",
+				"window3",
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_1.json
@@ -176,6 +176,64 @@
 				"window3Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_light/roof_5"
+			],
+			"positionDefinitions": [
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_1/roof_1",
+				"end/end_side_1/roof_2",
+				"end/end_side_1/roof_3",
+				"end/end_side_1/roof_4",
+				"end/end_side_2/roof",
+				"end/end_side_2/roof_2",
+				"end/end_side_2/roof_3",
+				"end/end_side_2/roof_4",
+				"end/end_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_side_1/roof_1",
+				"head_exterior/head_side_1/roof_2",
+				"head_exterior/head_side_1/roof_3",
+				"head_exterior/head_side_1/roof_4",
+				"head_exterior/head_side_1/roof_7",
+				"head_exterior/head_side_1/roof_9",
+				"head_exterior/head_side_1/roof_10",
+				"head_exterior/head_side_1/roof_11",
+				"head_exterior/head_side_1/roof_12",
+				"head_exterior/head_side_2/roof_2",
+				"head_exterior/head_side_2/roof_3",
+				"head_exterior/head_side_2/roof_4",
+				"head_exterior/head_side_2/roof_5",
+				"head_exterior/head_side_2/roof_8",
+				"head_exterior/head_side_2/roof_10",
+				"head_exterior/head_side_2/roof_11",
+				"head_exterior/head_side_2/roof_12",
+				"head_exterior/head_side_2/roof_13",
+				"head_exterior/middle/roof_9",
+				"head_exterior/middle/roof_5",
+				"head_exterior/middle/roof_6",
+				"head_exterior/middle/roof_8",
+				"head_exterior/middle/roof_10"
+			],
+			"positionDefinitions": [
+				"window1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_2.json
@@ -176,6 +176,64 @@
 				"window8Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_light/roof_5"
+			],
+			"positionDefinitions": [
+				"window7"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_1/roof_1",
+				"end/end_side_1/roof_2",
+				"end/end_side_1/roof_3",
+				"end/end_side_1/roof_4",
+				"end/end_side_2/roof",
+				"end/end_side_2/roof_2",
+				"end/end_side_2/roof_3",
+				"end/end_side_2/roof_4",
+				"end/end_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window7"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_side_1/roof_1",
+				"head_exterior/head_side_1/roof_2",
+				"head_exterior/head_side_1/roof_3",
+				"head_exterior/head_side_1/roof_4",
+				"head_exterior/head_side_1/roof_7",
+				"head_exterior/head_side_1/roof_9",
+				"head_exterior/head_side_1/roof_10",
+				"head_exterior/head_side_1/roof_11",
+				"head_exterior/head_side_1/roof_12",
+				"head_exterior/head_side_2/roof_2",
+				"head_exterior/head_side_2/roof_3",
+				"head_exterior/head_side_2/roof_4",
+				"head_exterior/head_side_2/roof_5",
+				"head_exterior/head_side_2/roof_8",
+				"head_exterior/head_side_2/roof_10",
+				"head_exterior/head_side_2/roof_11",
+				"head_exterior/head_side_2/roof_12",
+				"head_exterior/head_side_2/roof_13",
+				"head_exterior/middle/roof_9",
+				"head_exterior/middle/roof_5",
+				"head_exterior/middle/roof_6",
+				"head_exterior/middle/roof_8",
+				"head_exterior/middle/roof_10"
+			],
+			"positionDefinitions": [
+				"window9"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_head_2.json
@@ -164,6 +164,18 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window7",
+				"window7Flipped",
+				"window8",
+				"window8Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_1a.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_1a.json
@@ -43,6 +43,42 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"window_end_exterior_1/window_end_exterior_1_1/roof_1",
+				"window_end_exterior_1/window_end_exterior_1_1/roof_2",
+				"window_end_exterior_1/window_end_exterior_1_2/roof_2",
+				"window_end_exterior_1/window_end_exterior_1_2/roof_3"
+			],
+			"positionDefinitions": [
+				"window4"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_2/window_end_exterior_2_1/roof_2",
+				"window_end_exterior_2/window_end_exterior_2_1/roof_3",
+				"window_end_exterior_2/window_end_exterior_2_2/roof_3",
+				"window_end_exterior_2/window_end_exterior_2_2/roof_4"
+			],
+			"positionDefinitions": [
+				"window5"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_3/window_end_exterior_3_1/roof_3",
+				"window_end_exterior_3/window_end_exterior_3_1/roof_4",
+				"window_end_exterior_3/window_end_exterior_3_2/roof_4",
+				"window_end_exterior_3/window_end_exterior_3_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window6"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_1b.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_1b.json
@@ -43,6 +43,42 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"window_end_exterior_4/window_end_exterior_4_1/roof_3",
+				"window_end_exterior_4/window_end_exterior_4_1/roof_4",
+				"window_end_exterior_4/window_end_exterior_4_2/roof_4",
+				"window_end_exterior_4/window_end_exterior_4_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window7"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_5/window_end_exterior_5_1/roof_4",
+				"window_end_exterior_5/window_end_exterior_5_1/roof_5",
+				"window_end_exterior_5/window_end_exterior_5_2/roof_5",
+				"window_end_exterior_5/window_end_exterior_5_2/roof_6"
+			],
+			"positionDefinitions": [
+				"window8"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_6/window_end_exterior_6_1/roof_5",
+				"window_end_exterior_6/window_end_exterior_6_1/roof_6",
+				"window_end_exterior_6/window_end_exterior_6_2/roof_6",
+				"window_end_exterior_6/window_end_exterior_6_2/roof_7"
+			],
+			"positionDefinitions": [
+				"window9"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_2a.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_2a.json
@@ -43,6 +43,42 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"window_end_exterior_1/window_end_exterior_1_1/roof_1",
+				"window_end_exterior_1/window_end_exterior_1_1/roof_2",
+				"window_end_exterior_1/window_end_exterior_1_2/roof_2",
+				"window_end_exterior_1/window_end_exterior_1_2/roof_3"
+			],
+			"positionDefinitions": [
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_2/window_end_exterior_2_1/roof_2",
+				"window_end_exterior_2/window_end_exterior_2_1/roof_3",
+				"window_end_exterior_2/window_end_exterior_2_2/roof_3",
+				"window_end_exterior_2/window_end_exterior_2_2/roof_4"
+			],
+			"positionDefinitions": [
+				"window5Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_3/window_end_exterior_3_1/roof_3",
+				"window_end_exterior_3/window_end_exterior_3_1/roof_4",
+				"window_end_exterior_3/window_end_exterior_3_2/roof_4",
+				"window_end_exterior_3/window_end_exterior_3_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window4Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_2b.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_2b.json
@@ -43,6 +43,42 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"window_end_exterior_4/window_end_exterior_4_1/roof_3",
+				"window_end_exterior_4/window_end_exterior_4_1/roof_4",
+				"window_end_exterior_4/window_end_exterior_4_2/roof_4",
+				"window_end_exterior_4/window_end_exterior_4_2/roof_5"
+			],
+			"positionDefinitions": [
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_5/window_end_exterior_5_1/roof_4",
+				"window_end_exterior_5/window_end_exterior_5_1/roof_5",
+				"window_end_exterior_5/window_end_exterior_5_2/roof_5",
+				"window_end_exterior_5/window_end_exterior_5_2/roof_6"
+			],
+			"positionDefinitions": [
+				"window2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_end_exterior_6/window_end_exterior_6_1/roof_5",
+				"window_end_exterior_6/window_end_exterior_6_1/roof_6",
+				"window_end_exterior_6/window_end_exterior_6_2/roof_6",
+				"window_end_exterior_6/window_end_exterior_6_2/roof_7"
+			],
+			"positionDefinitions": [
+				"window1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_default.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/class_802_window_default.json
@@ -107,6 +107,105 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"window_exterior_1/roof_1",
+				"window_exterior_1/roof_2"
+			],
+			"positionDefinitions": [
+				"window9",
+				"window1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_2/roof_1",
+				"window_exterior_2/roof_2"
+			],
+			"positionDefinitions": [
+				"window8",
+				"window2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_3/roof_1",
+				"window_exterior_3/roof_2"
+			],
+			"positionDefinitions": [
+				"window7",
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_4/roof_1",
+				"window_exterior_4/roof_2"
+			],
+			"positionDefinitions": [
+				"window6",
+				"window4Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_5/roof_1",
+				"window_exterior_5/roof_2"
+			],
+			"positionDefinitions": [
+				"window5",
+				"window5Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_6/roof_1",
+				"window_exterior_6/roof_2"
+			],
+			"positionDefinitions": [
+				"window4",
+				"window6Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_7/roof_1",
+				"window_exterior_7/roof_2"
+			],
+			"positionDefinitions": [
+				"window3",
+				"window7Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_8/roof_1",
+				"window_exterior_8/roof_2"
+			],
+			"positionDefinitions": [
+				"window2",
+				"window8Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_9/roof_1",
+				"window_exterior_9/roof_2"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window9Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_common.json
@@ -295,6 +295,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_common.json
@@ -339,6 +339,38 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_light"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"doorLight1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_1.json
@@ -129,6 +129,30 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_4"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_1.json
@@ -111,6 +111,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_2.json
@@ -129,6 +129,30 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_4"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/cm_stock_head_2.json
@@ -111,6 +111,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_common.json
@@ -345,6 +345,49 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_1",
+				"roof_window_2",
+				"roof_window_3"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"window2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"doorMiddle",
+				"doorMiddleFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorMiddle",
+				"doorMiddleFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_common.json
@@ -388,6 +388,36 @@
 				"doorMiddleFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light",
+				"roof_window_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"window2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"doorMiddle",
+				"doorMiddleFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"doorLight"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_1.json
@@ -37,6 +37,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_1.json
@@ -55,6 +55,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_2.json
@@ -55,6 +55,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_end_2.json
@@ -37,6 +37,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_1.json
@@ -85,6 +85,31 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_1.json
@@ -67,6 +67,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_2.json
@@ -67,6 +67,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/drl_head_2.json
@@ -85,6 +85,31 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_common.json
@@ -226,6 +226,44 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_window"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_common.json
@@ -264,6 +264,34 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window_light"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_light"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"doorLight"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_1.json
@@ -56,6 +56,33 @@
 				"end1Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"end1Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_1.json
@@ -83,6 +83,33 @@
 				"end1Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_handrails"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_2.json
@@ -56,6 +56,33 @@
 				"end2Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"end2Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_end_2.json
@@ -83,6 +83,33 @@
 				"end2Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_handrails"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_1.json
@@ -153,6 +153,47 @@
 				"end1Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end1Vents"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_1/outer_roof_11",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_11",
+				"head_exterior/front/head_roof"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_1.json
@@ -135,6 +135,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"end1Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_2.json
@@ -135,6 +135,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"end2Roof"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/e44_head_2.json
@@ -153,6 +153,47 @@
 				"end2Roof"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end2Vents"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_1/outer_roof_11",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_11",
+				"head_exterior/front/head_roof"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
@@ -309,6 +309,50 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_window_light"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_light"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_window/roof1",
+				"window/roof_window/roof2",
+				"window/roof_window/roof3",
+				"window/roof_window/roof4"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof_door/roof1",
+				"door/roof_door/roof2",
+				"door/roof_door/roof3",
+				"door/roof_door/roof4"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_common.json
@@ -298,6 +298,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"window"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_end_1.json
@@ -43,6 +43,41 @@
 			"condition": "NORMAL",
 			"renderStage": "LIGHT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end_forward"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/roof1",
+				"end/roof2",
+				"end/roof3",
+				"end/roof4"
+			],
+			"positionDefinitions": [
+				"end_forward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end_exterior/roof2",
+				"end_exterior/roof3",
+				"end_exterior/roof1",
+				"end_exterior/roof4"
+			],
+			"positionDefinitions": [
+				"end_forward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_end_2.json
@@ -43,6 +43,41 @@
 			"condition": "NORMAL",
 			"renderStage": "LIGHT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end_backward"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/roof1",
+				"end/roof2",
+				"end/roof3",
+				"end/roof4"
+			],
+			"positionDefinitions": [
+				"end_backward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end_exterior/roof2",
+				"end_exterior/roof3",
+				"end_exterior/roof1",
+				"end_exterior/roof4"
+			],
+			"positionDefinitions": [
+				"end_backward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_1.json
@@ -276,6 +276,58 @@
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": ""
+		},
+		{
+			"names": [
+				"roof_head_light"
+			],
+			"positionDefinitions": [
+				"cab_forward"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head/roof4",
+				"head/roof3",
+				"head/roof2",
+				"head/roof1"
+			],
+			"positionDefinitions": [
+				"cab_forward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_exterior/roof4",
+				"head_exterior/roof2",
+				"head_exterior/roof3",
+				"head_exterior/roof1",
+				"head_exterior/roof9",
+				"head_exterior/roof10",
+				"head_exterior/roof11",
+				"head_exterior/roof12"
+			],
+			"positionDefinitions": [
+				"cab_forward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_driver/roof4",
+				"head_driver/roof3",
+				"head_driver/roof2",
+				"head_driver/roof1"
+			],
+			"positionDefinitions": [
+				"cab_forward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "ON_ROUTE_BACKWARDS"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/eidan_9000_head_2.json
@@ -275,6 +275,58 @@
 			"displayOptions": [],
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX"
+		},
+		{
+			"names": [
+				"roof_head_light"
+			],
+			"positionDefinitions": [
+				"cab_backward"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head/roof4",
+				"head/roof3",
+				"head/roof2",
+				"head/roof1"
+			],
+			"positionDefinitions": [
+				"cab_backward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_exterior/roof4",
+				"head_exterior/roof2",
+				"head_exterior/roof3",
+				"head_exterior/roof1",
+				"head_exterior/roof9",
+				"head_exterior/roof10",
+				"head_exterior/roof11",
+				"head_exterior/roof12"
+			],
+			"positionDefinitions": [
+				"cab_backward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_driver/roof4",
+				"head_driver/roof3",
+				"head_driver/roof2",
+				"head_driver/roof1"
+			],
+			"positionDefinitions": [
+				"cab_backward"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "ON_ROUTE_FORWARDS"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_common.json
@@ -305,6 +305,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_common.json
@@ -349,6 +349,31 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_3"
+			],
+			"positionDefinitions": [
+				"doorLight3"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_1.json
@@ -37,6 +37,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_1.json
@@ -55,6 +55,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_2.json
@@ -55,6 +55,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_end_2.json
@@ -37,6 +37,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_1.json
@@ -114,6 +114,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_1.json
@@ -132,6 +132,31 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_2.json
@@ -114,6 +114,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_head_2.json
@@ -132,6 +132,31 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_common.json
@@ -290,6 +290,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_common.json
@@ -334,6 +334,31 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_3"
+			],
+			"positionDefinitions": [
+				"doorLight3"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_1.json
@@ -104,6 +104,24 @@
 			"doorXMultiplier": -1,
 			"doorZMultiplier": -14,
 			"doorAnimationType": "PLUG_SLOW"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_1.json
@@ -122,6 +122,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_2.json
@@ -122,6 +122,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_end_2.json
@@ -104,6 +104,24 @@
 			"doorXMultiplier": -1,
 			"doorZMultiplier": -14,
 			"doorAnimationType": "PLUG_SLOW"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_1.json
@@ -177,6 +177,31 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_1.json
@@ -159,6 +159,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_2.json
@@ -177,6 +177,31 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/k_train_tcl_ael_head_2.json
@@ -159,6 +159,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1.json
@@ -493,6 +493,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1.json
@@ -541,6 +541,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1r.json
@@ -501,6 +501,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_1r.json
@@ -549,6 +549,44 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3",
+				"head_exterior_4/destination_roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2.json
@@ -493,6 +493,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2.json
@@ -541,6 +541,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2r.json
@@ -501,6 +501,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_2r.json
@@ -549,6 +549,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_5"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3.json
@@ -493,6 +493,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3.json
@@ -541,6 +541,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3r.json
@@ -501,6 +501,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3r.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_3r.json
@@ -549,6 +549,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_4.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_4.json
@@ -501,6 +501,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_4.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_4.json
@@ -549,6 +549,44 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3",
+				"head_exterior_4/destination_roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_5.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_5.json
@@ -501,6 +501,54 @@
 				"end2"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_5.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/light_rail_5.json
@@ -549,6 +549,43 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_5"
+			],
+			"positionDefinitions": [
+				"windowPart",
+				"door",
+				"doorFlipped",
+				"end1",
+				"end1Flipped",
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/inner_roof_3"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/inner_roof_1",
+				"end/inner_roof_2",
+				"end/inner_roof_3",
+				"end/inner_roof_4",
+				"end/inner_roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_common.json
@@ -241,6 +241,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"window/window_1/roof_1",
+				"window/window_1/roof_2",
+				"window/window_1/roof_3",
+				"window/window_2/roof_2",
+				"window/window_2/roof_3",
+				"window/window_2/roof_4"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowEnd1",
+				"windowEnd2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_exterior_1/roof_1",
+				"window_exterior/window_exterior_1/roof_2",
+				"window_exterior/window_exterior_1/roof_3",
+				"window_exterior/window_exterior_2/roof_2",
+				"window_exterior/window_exterior_2/roof_3",
+				"window_exterior/window_exterior_2/roof_4"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowEnd1",
+				"windowEnd2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/window_1/door_roof",
+				"window/window_2/door_roof"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowEnd1",
+				"windowEnd2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_end_1.json
@@ -205,6 +205,58 @@
 			"renderStage": "EXTERIOR",
 			"doorZMultiplier": -12,
 			"doorAnimationType": "STANDARD"
+		},
+		{
+			"names": [
+				"window/window_1/roof_1",
+				"window/window_1/roof_2",
+				"window/window_1/roof_3",
+				"window/window_2/roof_2",
+				"window/window_2/roof_3",
+				"window/window_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_exterior_1/roof_1",
+				"window_exterior/window_exterior_1/roof_2",
+				"window_exterior/window_exterior_1/roof_3",
+				"window_exterior/window_exterior_2/roof_2",
+				"window_exterior/window_exterior_2/roof_3",
+				"window_exterior/window_exterior_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_1/roof_1",
+				"end/end_1/roof_2",
+				"end/end_1/roof_3",
+				"end/end_2/roof_2",
+				"end/end_2/roof_3",
+				"end/end_2/roof_4"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/window_1/door_roof",
+				"window/window_2/door_roof"
+			],
+			"positionDefinitions": [
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_end_2.json
@@ -205,6 +205,58 @@
 			"renderStage": "EXTERIOR",
 			"doorZMultiplier": -12,
 			"doorAnimationType": "STANDARD"
+		},
+		{
+			"names": [
+				"window/window_1/roof_1",
+				"window/window_1/roof_2",
+				"window/window_1/roof_3",
+				"window/window_2/roof_2",
+				"window/window_2/roof_3",
+				"window/window_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_exterior_1/roof_1",
+				"window_exterior/window_exterior_1/roof_2",
+				"window_exterior/window_exterior_1/roof_3",
+				"window_exterior/window_exterior_2/roof_2",
+				"window_exterior/window_exterior_2/roof_3",
+				"window_exterior/window_exterior_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_1/roof_1",
+				"end/end_1/roof_2",
+				"end/end_1/roof_3",
+				"end/end_2/roof_2",
+				"end/end_2/roof_3",
+				"end/end_2/roof_4"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/window_1/door_roof",
+				"window/window_2/door_roof"
+			],
+			"positionDefinitions": [
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_head_1.json
@@ -116,6 +116,34 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"head/head_1/roof_1",
+				"head/head_1/roof_2",
+				"head/head_1/roof_3",
+				"head/head_2/roof_2",
+				"head/head_2/roof_3",
+				"head/head_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_1/roof_1",
+				"head_exterior/head_exterior_1/roof_2",
+				"head_exterior/head_exterior_1/roof_3",
+				"head_exterior/head_exterior_2/roof_2",
+				"head_exterior/head_exterior_2/roof_3",
+				"head_exterior/head_exterior_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_1995_head_2.json
@@ -116,6 +116,34 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"head/head_1/roof_1",
+				"head/head_1/roof_2",
+				"head/head_1/roof_3",
+				"head/head_2/roof_2",
+				"head/head_2/roof_3",
+				"head/head_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_1/roof_1",
+				"head_exterior/head_exterior_1/roof_2",
+				"head_exterior/head_exterior_1/roof_3",
+				"head_exterior/head_exterior_2/roof_2",
+				"head_exterior/head_exterior_2/roof_3",
+				"head_exterior/head_exterior_2/roof_4"
+			],
+			"positionDefinitions": [
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_common.json
@@ -250,6 +250,64 @@
 			"renderStage": "EXTERIOR",
 			"doorZMultiplier": 17,
 			"doorAnimationType": "STANDARD"
+		},
+		{
+			"names": [
+				"window/window_1/roof_side",
+				"window/window_1/roof",
+				"window/window_3/roof_side",
+				"window/window_3/roof"
+			],
+			"positionDefinitions": [
+				"windowEnd",
+				"windowMiddle"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_2/roof_1",
+				"window_exterior/window_2/roof_2",
+				"window_exterior/window_2/roof_3",
+				"window_exterior/window_2/roof",
+				"window_exterior/window_6/roof_2",
+				"window_exterior/window_6/roof_3",
+				"window_exterior/window_6/roof_4",
+				"window_exterior/window_6/roof"
+			],
+			"positionDefinitions": [
+				"windowEnd",
+				"windowMiddle"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof",
+				"door/roof_side"
+			],
+			"positionDefinitions": [
+				"door1",
+				"door1Flipped",
+				"door2",
+				"door2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_exterior/roof_1",
+				"door_exterior/roof_2",
+				"door_exterior/roof_3",
+				"door_exterior/roof"
+			],
+			"positionDefinitions": [
+				"door1",
+				"door1Flipped",
+				"door2",
+				"door2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_end_1.json
@@ -90,6 +90,62 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"window/window_1/roof_side",
+				"window/window_1/roof",
+				"window/window_3/roof_side",
+				"window/window_3/roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/window_5/roof_side",
+				"end/window_5/roof",
+				"end/window_10/roof_side",
+				"end/window_10/roof"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_2/roof_1",
+				"window_exterior/window_2/roof_2",
+				"window_exterior/window_2/roof_3",
+				"window_exterior/window_2/roof",
+				"window_exterior/window_6/roof_2",
+				"window_exterior/window_6/roof_3",
+				"window_exterior/window_6/roof_4",
+				"window_exterior/window_6/roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/window_7/roof_1",
+				"end_exterior/window_7/roof_2",
+				"end_exterior/window_7/roof_3",
+				"end_exterior/window_7/roof",
+				"end_exterior/window_12/roof_2",
+				"end_exterior/window_12/roof_3",
+				"end_exterior/window_12/roof_4",
+				"end_exterior/window_12/roof"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_end_2.json
@@ -90,6 +90,62 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"window/window_1/roof_side",
+				"window/window_1/roof",
+				"window/window_3/roof_side",
+				"window/window_3/roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/window_5/roof_side",
+				"end/window_5/roof",
+				"end/window_10/roof_side",
+				"end/window_10/roof"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/window_2/roof_1",
+				"window_exterior/window_2/roof_2",
+				"window_exterior/window_2/roof_3",
+				"window_exterior/window_2/roof",
+				"window_exterior/window_6/roof_2",
+				"window_exterior/window_6/roof_3",
+				"window_exterior/window_6/roof_4",
+				"window_exterior/window_6/roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/window_7/roof_1",
+				"end_exterior/window_7/roof_2",
+				"end_exterior/window_7/roof_3",
+				"end_exterior/window_7/roof",
+				"end_exterior/window_12/roof_2",
+				"end_exterior/window_12/roof_3",
+				"end_exterior/window_12/roof_4",
+				"end_exterior/window_12/roof"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_head_1.json
@@ -123,6 +123,34 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"head/window_11/roof_side",
+				"head/window_11/roof",
+				"head/window_14/roof_side",
+				"head/window_14/roof"
+			],
+			"positionDefinitions": [
+				"head1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/window_9/roof_2",
+				"head_exterior/window_9/roof_3",
+				"head_exterior/window_9/roof_4",
+				"head_exterior/window_9/roof",
+				"head_exterior/window_16/roof_3",
+				"head_exterior/window_16/roof_4",
+				"head_exterior/window_16/roof_5",
+				"head_exterior/window_16/roof"
+			],
+			"positionDefinitions": [
+				"head1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_d78_head_2.json
@@ -123,6 +123,34 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_UK"
+		},
+		{
+			"names": [
+				"head/window_11/roof_side",
+				"head/window_11/roof",
+				"head/window_14/roof_side",
+				"head/window_14/roof"
+			],
+			"positionDefinitions": [
+				"head2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/window_9/roof_2",
+				"head_exterior/window_9/roof_3",
+				"head_exterior/window_9/roof_4",
+				"head_exterior/window_9/roof",
+				"head_exterior/window_16/roof_3",
+				"head_exterior/window_16/roof_4",
+				"head_exterior/window_16/roof_5",
+				"head_exterior/window_16/roof"
+			],
+			"positionDefinitions": [
+				"head2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_1.json
@@ -514,6 +514,26 @@
 			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"16cbb1b2"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"fabfd6c2"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_1.json
@@ -534,6 +534,56 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"53d2eed6"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"621d235a"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"cb729c1b"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"ac595829"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"7310a300"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_2.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -475,17 +475,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"UPPER_CASE"
 			],
-			"displayPadZeros": 3.0,
+			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": "000"
 		},
@@ -499,21 +499,41 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"aed328c"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"e2b0fa07"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -522,6 +542,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_2.json
@@ -531,6 +531,56 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"424b3f14"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"4436b8d2"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"62178d25"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"5ff75c6a"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"99e09ccf"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_3.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -420,17 +420,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"UPPER_CASE"
 			],
-			"displayPadZeros": 3.0,
+			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": "000"
 		},
@@ -444,16 +444,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -478,9 +478,29 @@
 			"condition": "ON_ROUTE_FORWARDS",
 			"renderStage": "ALWAYS_ON_LIGHT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"923f7588"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"91564908"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -489,6 +509,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_cab_3.json
@@ -498,6 +498,46 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"8da58081"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"64facc99"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"17fc1ddd"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"5f310f16"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_trailer.json
@@ -374,6 +374,36 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"b7d00fb7"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"96e9a23a"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"768cb543"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s7_trailer.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -354,9 +354,29 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "SEAT"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"e8597728"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"7f17eb6d"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -365,6 +385,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_1.json
@@ -553,6 +553,56 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"2b7ff00"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"e6ce3226"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"e948331e"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"3c1dc785"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"b5545a02"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_1.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -475,17 +475,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"UPPER_CASE"
 			],
-			"displayPadZeros": 3.0,
+			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": "000"
 		},
@@ -499,16 +499,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -533,9 +533,29 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR_TRANSLUCENT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"99feca2d"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"3a80bced"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -544,6 +564,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_2.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -475,17 +475,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"UPPER_CASE"
 			],
-			"displayPadZeros": 3.0,
+			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": "000"
 		},
@@ -499,16 +499,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -533,9 +533,29 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR_TRANSLUCENT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"73ed247c"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"7bb75b51"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -544,6 +564,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_2.json
@@ -553,6 +553,56 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"635afba5"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"597d63db"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"77f34162"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"9711e2ed"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"532165d"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_3.json
@@ -520,6 +520,46 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"e7b304ec"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"c199beca"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro/roof4/cube"
+			],
+			"positionDefinitions": [
+				"7ba40b59"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"head_ushiro_exterior/roof_head_ushiro/cube"
+			],
+			"positionDefinitions": [
+				"1ba820d9"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_3.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_cab_3.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -420,17 +420,17 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"UPPER_CASE"
 			],
-			"displayPadZeros": 3.0,
+			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
 			"displayDefaultText": "000"
 		},
@@ -444,16 +444,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -500,9 +500,29 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR_TRANSLUCENT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"c112618e"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"19a70c8"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -511,6 +531,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_trailer.json
@@ -396,6 +396,36 @@
 			],
 			"type": "WEATHER_COVER",
 			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"window/roof/cube"
+			],
+			"positionDefinitions": [
+				"3c8d538"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"door/roof2/cube"
+			],
+			"positionDefinitions": [
+				"19549c75"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"end/roof3/cube"
+			],
+			"positionDefinitions": [
+				"a17f441b"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/london_underground_s8_trailer.json
@@ -65,16 +65,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"SCROLL_NORMAL"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "NEXT_STATION_UK",
 			"displayDefaultText": "This train is terminating here. All change please."
 		},
@@ -154,16 +154,16 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [
 				"CYCLE_LANGUAGES"
 			],
-			"displayPadZeros": 0.0,
+			"displayPadZeros": 0,
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
 		},
@@ -210,7 +210,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -224,7 +224,7 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -238,7 +238,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": -11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -252,7 +252,7 @@
 			"condition": "NORMAL",
 			"renderStage": "EXTERIOR",
 			"type": "NORMAL",
-			"doorXMultiplier": 0.0,
+			"doorXMultiplier": 0,
 			"doorZMultiplier": 11.5,
 			"doorAnimationType": "CONSTANT"
 		},
@@ -376,9 +376,29 @@
 			"condition": "NORMAL",
 			"renderStage": "INTERIOR_TRANSLUCENT",
 			"type": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior_aircon"
+			],
+			"positionDefinitions": [
+				"55b08c5e"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"53f01539"
+			],
+			"type": "WEATHER_COVER",
+			"condition": "NORMAL"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/london_underground_s7_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/london_underground_s7_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/london_underground_s7_floor.png",
@@ -387,6 +407,6 @@
 	"gangwayOuterBottomResource": "mtr:textures/gangway/london_underground_s7_exterior.png",
 	"gangwayWidth": 1.5,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.5
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_common.json
@@ -341,6 +341,31 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"doorLight1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_common.json
@@ -297,6 +297,50 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_1.json
@@ -37,6 +37,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_1.json
@@ -55,6 +55,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_2.json
@@ -55,6 +55,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_end_2.json
@@ -37,6 +37,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_1.json
@@ -131,6 +131,31 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_1.json
@@ -113,6 +113,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_2.json
@@ -113,6 +113,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/m_train_head_2.json
@@ -131,6 +131,31 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_common.json
@@ -326,6 +326,27 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window2",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_light/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"doorLight"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_common.json
@@ -270,6 +270,62 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_door_top_overlay.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_door_top_overlay.json
@@ -43,6 +43,24 @@
 			"renderStage": "EXTERIOR",
 			"doorZMultiplier": -14,
 			"doorAnimationType": "MLR"
+		},
+		{
+			"names": [
+				"door_left/outer_roof_1"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_right/outer_roof_2"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_1.json
@@ -84,6 +84,24 @@
 				"end1Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_1.json
@@ -56,6 +56,34 @@
 				"end1Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end1",
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_2.json
@@ -56,6 +56,34 @@
 				"end2Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_end_2.json
@@ -84,6 +84,24 @@
 				"end2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_1.json
@@ -157,6 +157,54 @@
 				"end1Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"roofHead1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_1/outer_roof_9",
+				"head_exterior/front/side_1/outer_roof_10",
+				"head_exterior/front/side_1/outer_roof_11",
+				"head_exterior/front/side_2/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_9",
+				"head_exterior/front/side_2/outer_roof_10",
+				"head_exterior/front/side_2/outer_roof_11"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_1.json
@@ -138,6 +138,25 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end1",
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_2.json
@@ -138,6 +138,25 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"end2",
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mlr_head_2.json
@@ -157,6 +157,54 @@
 				"end2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_vents"
+			],
+			"positionDefinitions": [
+				"roofHead2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/side_1/outer_roof_1",
+				"head_exterior/front/side_1/outer_roof_2",
+				"head_exterior/front/side_1/outer_roof_3",
+				"head_exterior/front/side_1/outer_roof_4",
+				"head_exterior/front/side_1/outer_roof_5",
+				"head_exterior/front/side_1/outer_roof_6",
+				"head_exterior/front/side_1/outer_roof_7",
+				"head_exterior/front/side_1/outer_roof_8",
+				"head_exterior/front/side_1/outer_roof_9",
+				"head_exterior/front/side_1/outer_roof_10",
+				"head_exterior/front/side_1/outer_roof_11",
+				"head_exterior/front/side_2/outer_roof_1",
+				"head_exterior/front/side_2/outer_roof_2",
+				"head_exterior/front/side_2/outer_roof_3",
+				"head_exterior/front/side_2/outer_roof_4",
+				"head_exterior/front/side_2/outer_roof_5",
+				"head_exterior/front/side_2/outer_roof_6",
+				"head_exterior/front/side_2/outer_roof_7",
+				"head_exterior/front/side_2/outer_roof_8",
+				"head_exterior/front/side_2/outer_roof_9",
+				"head_exterior/front/side_2/outer_roof_10",
+				"head_exterior/front/side_2/outer_roof_11"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_common.json
@@ -322,6 +322,33 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"roof_door_exterior_1"
+			],
+			"positionDefinitions": [
+				"roofDoor1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_exterior_2"
+			],
+			"positionDefinitions": [
+				"roofDoor2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_exterior_3"
+			],
+			"positionDefinitions": [
+				"roofDoor3"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_common.json
@@ -349,6 +349,40 @@
 				"roofDoor3"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_3",
+				"window/roof_5"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/roof_1",
+				"window_exterior/roof_2",
+				"window_exterior/roof_3",
+				"window_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_1",
+				"door/roof_3",
+				"door/roof_5"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_end_1.json
@@ -36,6 +36,43 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"end_roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_2/roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_side_1/roof",
+				"end_exterior/end_exterior_side_1/roof_1",
+				"end_exterior/end_exterior_side_1/roof_2",
+				"end_exterior/end_exterior_side_1/roof_3",
+				"end_exterior/end_exterior_side_1/roof_4",
+				"end_exterior/end_exterior_side_2/roof",
+				"end_exterior/end_exterior_side_2/roof_2",
+				"end_exterior/end_exterior_side_2/roof_3",
+				"end_exterior/end_exterior_side_2/roof_4",
+				"end_exterior/end_exterior_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_end_2.json
@@ -36,6 +36,43 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"end_roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end/end_side_1/roof",
+				"end/end_side_2/roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_side_1/roof",
+				"end_exterior/end_exterior_side_1/roof_1",
+				"end_exterior/end_exterior_side_1/roof_2",
+				"end_exterior/end_exterior_side_1/roof_3",
+				"end_exterior/end_exterior_side_1/roof_4",
+				"end_exterior/end_exterior_side_2/roof",
+				"end_exterior/end_exterior_side_2/roof_2",
+				"end_exterior/end_exterior_side_2/roof_3",
+				"end_exterior/end_exterior_side_2/roof_4",
+				"end_exterior/end_exterior_side_2/roof_5"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_head_1.json
@@ -76,6 +76,45 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"end_roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head/head_side_1/roof",
+				"head/head_side_2/roof"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_side_1/roof_5",
+				"head_exterior/head_exterior_side_1/roof_4",
+				"head_exterior/head_exterior_side_1/roof_3",
+				"head_exterior/head_exterior_side_1/roof_2",
+				"head_exterior/head_exterior_side_1/roof_1",
+				"head_exterior/head_exterior_side_1/roof_8",
+				"head_exterior/head_exterior_side_2/roof_2",
+				"head_exterior/head_exterior_side_2/roof_3",
+				"head_exterior/head_exterior_side_2/roof_4",
+				"head_exterior/head_exterior_side_2/roof_5",
+				"head_exterior/head_exterior_side_2/roof_6",
+				"head_exterior/head_exterior_side_2/roof_9"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_16_head_2.json
@@ -76,6 +76,45 @@
 			],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
+		},
+		{
+			"names": [
+				"end_roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head/head_side_1/roof",
+				"head/head_side_2/roof"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/head_exterior_side_1/roof_5",
+				"head_exterior/head_exterior_side_1/roof_4",
+				"head_exterior/head_exterior_side_1/roof_3",
+				"head_exterior/head_exterior_side_1/roof_2",
+				"head_exterior/head_exterior_side_1/roof_1",
+				"head_exterior/head_exterior_side_1/roof_8",
+				"head_exterior/head_exterior_side_2/roof_2",
+				"head_exterior/head_exterior_side_2/roof_3",
+				"head_exterior/head_exterior_side_2/roof_4",
+				"head_exterior/head_exterior_side_2/roof_5",
+				"head_exterior/head_exterior_side_2/roof_6",
+				"head_exterior/head_exterior_side_2/roof_9"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_85.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_85.json
@@ -329,6 +329,94 @@
 				"roofDoor3"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window/roof_1",
+				"window/roof_2",
+				"window/roof_3",
+				"window/roof_4",
+				"window/roof_5"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior/roof_1",
+				"window_exterior/roof_2",
+				"window_exterior/roof_3",
+				"window_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_1",
+				"door/roof_2",
+				"door/roof_3",
+				"door/roof_4",
+				"door/roof_5"
+			],
+			"positionDefinitions": [
+				"door"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head/side_1/roof_1",
+				"head/side_1/roof_2",
+				"head/side_1/roof_3",
+				"head/side_1/roof_4",
+				"head/side_1/roof_5",
+				"head/side_1/roof_6",
+				"head/side_1/roof_7",
+				"head/side_1/roof_8",
+				"head/side_2/roof_2",
+				"head/side_2/roof_3",
+				"head/side_2/roof_4",
+				"head/side_2/roof_5",
+				"head/side_2/roof_6",
+				"head/side_2/roof_7",
+				"head/side_2/roof_8",
+				"head/side_2/roof_9"
+			],
+			"positionDefinitions": [
+				"end1",
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/side_1_exterior/roof_1",
+				"head_exterior/side_1_exterior/roof_2",
+				"head_exterior/side_1_exterior/roof_3",
+				"head_exterior/side_1_exterior/roof_4",
+				"head_exterior/side_1_exterior/roof_5",
+				"head_exterior/side_1_exterior/roof_6",
+				"head_exterior/side_1_exterior/roof_7",
+				"head_exterior/side_1_exterior/roof_8",
+				"head_exterior/side_2_exterior/roof_2",
+				"head_exterior/side_2_exterior/roof_3",
+				"head_exterior/side_2_exterior/roof_4",
+				"head_exterior/side_2_exterior/roof_5",
+				"head_exterior/side_2_exterior/roof_6",
+				"head_exterior/side_2_exterior/roof_7",
+				"head_exterior/side_2_exterior/roof_8",
+				"head_exterior/side_2_exterior/roof_9"
+			],
+			"positionDefinitions": [
+				"end1",
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_85.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/mpl_85.json
@@ -302,6 +302,33 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_door_exterior_1"
+			],
+			"positionDefinitions": [
+				"roofDoor1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_exterior_2"
+			],
+			"positionDefinitions": [
+				"roofDoor2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_exterior_3"
+			],
+			"positionDefinitions": [
+				"roofDoor3"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/ngong_ping_360_lht.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/ngong_ping_360_lht.json
@@ -60,6 +60,15 @@
 				"main"
 			],
 			"type": "DOORWAY"
+		},
+		{
+			"names": [
+				"body/roof"
+			],
+			"positionDefinitions": [
+				"main"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": -5

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/ngong_ping_360_rht.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/ngong_ping_360_rht.json
@@ -60,6 +60,15 @@
 				"mainFlipped"
 			],
 			"type": "DOORWAY"
+		},
+		{
+			"names": [
+				"body/roof"
+			],
+			"positionDefinitions": [
+				"mainFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": -5

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_common.json
@@ -296,6 +296,34 @@
 				"doorEnd"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window_light"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_handle"
+			],
+			"positionDefinitions": [
+				"roofHandle"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_light"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_common.json
@@ -258,6 +258,44 @@
 				"CYCLE_LANGUAGES"
 			],
 			"displayType": "ROUTE_NUMBER"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_window"
+			],
+			"positionDefinitions": [
+				"window"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_1.json
@@ -55,6 +55,42 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior/outer_roof_1",
+				"end_exterior/roof_end_exterior/outer_roof_2",
+				"end_exterior/roof_end_exterior/outer_roof_3",
+				"end_exterior/roof_end_exterior/outer_roof_4",
+				"end_exterior/roof_end_exterior/outer_roof_5",
+				"end_exterior/roof_end_exterior/outer_roof_6",
+				"end_exterior/roof_end_exterior/outer_roof_7"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_handrails/end_mid_roof_4",
+				"end_handrails/end_mid_roof_3",
+				"end_handrails/end_mid_roof_2",
+				"end_handrails/end_mid_roof_1"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_1.json
@@ -46,6 +46,15 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_2.json
@@ -55,6 +55,42 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior/outer_roof_1",
+				"end_exterior/roof_end_exterior/outer_roof_2",
+				"end_exterior/roof_end_exterior/outer_roof_3",
+				"end_exterior/roof_end_exterior/outer_roof_4",
+				"end_exterior/roof_end_exterior/outer_roof_5",
+				"end_exterior/roof_end_exterior/outer_roof_6",
+				"end_exterior/roof_end_exterior/outer_roof_7"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_handrails/end_mid_roof_4",
+				"end_handrails/end_mid_roof_3",
+				"end_handrails/end_mid_roof_2",
+				"end_handrails/end_mid_roof_1"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_end_2.json
@@ -46,6 +46,15 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_1.json
@@ -102,6 +102,30 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof_head_exterior/outer_roof_2",
+				"head_exterior/roof_head_exterior/outer_roof_3",
+				"head_exterior/roof_head_exterior/outer_roof_4",
+				"head_exterior/roof_head_exterior/outer_roof_5",
+				"head_exterior/roof_head_exterior/outer_roof_6",
+				"head_exterior/roof_head_exterior/outer_roof_7",
+				"head_exterior/roof_head_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_1.json
@@ -93,6 +93,15 @@
 				"CYCLE_LANGUAGES"
 			],
 			"displayType": "ROUTE_NUMBER"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_2.json
@@ -75,6 +75,15 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r179_head_2.json
@@ -84,6 +84,30 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof_head_exterior/outer_roof_2",
+				"head_exterior/roof_head_exterior/outer_roof_3",
+				"head_exterior/roof_head_exterior/outer_roof_4",
+				"head_exterior/roof_head_exterior/outer_roof_5",
+				"head_exterior/roof_head_exterior/outer_roof_6",
+				"head_exterior/roof_head_exterior/outer_roof_7",
+				"head_exterior/roof_head_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_common.json
@@ -228,6 +228,58 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window3",
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window3",
+				"window3Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd1",
+				"doorEnd1Flipped",
+				"doorEnd2",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd1",
+				"doorEnd1Flipped",
+				"doorEnd2",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_common.json
@@ -280,6 +280,33 @@
 				"doorEnd2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window1",
+				"window1Flipped",
+				"window2",
+				"window3",
+				"window3Flipped",
+				"roofLight"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorEnd1",
+				"doorEnd1Flipped",
+				"doorEnd2",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_1.json
@@ -96,6 +96,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_1.json
@@ -105,6 +105,30 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"end1Light"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior/outer_roof_1",
+				"end_exterior/roof_end_exterior/outer_roof_2",
+				"end_exterior/roof_end_exterior/outer_roof_3",
+				"end_exterior/roof_end_exterior/outer_roof_4",
+				"end_exterior/roof_end_exterior/outer_roof_5",
+				"end_exterior/roof_end_exterior/outer_roof_6",
+				"end_exterior/roof_end_exterior/outer_roof_7"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_2.json
@@ -96,6 +96,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_end_2.json
@@ -105,6 +105,30 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"end2Light"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/roof_end_exterior/outer_roof_1",
+				"end_exterior/roof_end_exterior/outer_roof_2",
+				"end_exterior/roof_end_exterior/outer_roof_3",
+				"end_exterior/roof_end_exterior/outer_roof_4",
+				"end_exterior/roof_end_exterior/outer_roof_5",
+				"end_exterior/roof_end_exterior/outer_roof_6",
+				"end_exterior/roof_end_exterior/outer_roof_7"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_1.json
@@ -189,6 +189,30 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"head1Light"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof_head_exterior/outer_roof_2",
+				"head_exterior/roof_head_exterior/outer_roof_3",
+				"head_exterior/roof_head_exterior/outer_roof_4",
+				"head_exterior/roof_head_exterior/outer_roof_5",
+				"head_exterior/roof_head_exterior/outer_roof_6",
+				"head_exterior/roof_head_exterior/outer_roof_7",
+				"head_exterior/roof_head_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_1.json
@@ -180,6 +180,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_2.json
@@ -180,6 +180,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211_head_2.json
@@ -189,6 +189,30 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"head2Light"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof_head_exterior/outer_roof_2",
+				"head_exterior/roof_head_exterior/outer_roof_3",
+				"head_exterior/roof_head_exterior/outer_roof_4",
+				"head_exterior/roof_head_exterior/outer_roof_5",
+				"head_exterior/roof_head_exterior/outer_roof_6",
+				"head_exterior/roof_head_exterior/outer_roof_7",
+				"head_exterior/roof_head_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_1.json
@@ -104,6 +104,21 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_2",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_3",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_4",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_5",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_6",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_7",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_1.json
@@ -95,6 +95,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_end_gangway"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_2.json
@@ -95,6 +95,15 @@
 				"SCROLL_NORMAL"
 			],
 			"displayType": "NEXT_STATION_KCR"
+		},
+		{
+			"names": [
+				"roof_end_gangway"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r211t_end_2.json
@@ -104,6 +104,21 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_2",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_3",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_4",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_5",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_6",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_7",
+				"end_gangway_exterior/roof_end_gangway_exterior/outer_roof_8"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_common.json
@@ -302,6 +302,51 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window_1",
+				"roof_window_2"
+			],
+			"positionDefinitions": [
+				"windowOdd",
+				"windowEven"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_common.json
@@ -347,6 +347,36 @@
 				"doorEnd2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/door_light_roof"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_door_top_overlay.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_door_top_overlay.json
@@ -13,6 +13,20 @@
 				"doorEnd2Flipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"outer_roof"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_1.json
@@ -57,6 +57,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_1.json
@@ -75,6 +75,24 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"roofLight1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_2.json
@@ -57,6 +57,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_end_2.json
@@ -75,6 +75,24 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"roofLight2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_1.json
@@ -130,6 +130,36 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"roofLight1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_door/driver_door_edge_roof_1",
+				"head_exterior/driver_door/driver_door_edge_roof_3",
+				"head_exterior/driver_door/driver_door_edge_roof_4",
+				"head_exterior/driver_door/driver_door_edge_roof_2"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_1.json
@@ -112,6 +112,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_2.json
@@ -130,6 +130,36 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light"
+			],
+			"positionDefinitions": [
+				"roofLight2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_vent"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_door/driver_door_edge_roof_1",
+				"head_exterior/driver_door/driver_door_edge_roof_3",
+				"head_exterior/driver_door/driver_door_edge_roof_4",
+				"head_exterior/driver_door/driver_door_edge_roof_2"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/r_train_head_2.json
@@ -112,6 +112,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_head"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_head_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_cab_1.json
@@ -89,7 +89,7 @@
 				"ca8e1239"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -101,7 +101,7 @@
 				"3fb81a2b"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -113,7 +113,7 @@
 				"9b9d6ddd"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -125,7 +125,7 @@
 				"71c5b115"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -137,7 +137,7 @@
 				"97fd3db"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -149,7 +149,7 @@
 				"8c263012"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -236,8 +236,8 @@
 				"a2736284"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 0,
 			"renderUntilOpeningDoorTime": 1,
@@ -255,8 +255,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -350,12 +350,12 @@
 				"bc8089db"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
+			"displayXPadding": 0,
 			"displayYPadding": 0.2,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 2.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -383,12 +383,12 @@
 				"b0c017ab"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
-			"displayMaxLineHeight": 2.0,
-			"displayCjkSizeRatio": 1.0,
+			"displayMaxLineHeight": 2,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [],
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
@@ -403,11 +403,11 @@
 			],
 			"type": "DISPLAY",
 			"displayXPadding": 0.5,
-			"displayYPadding": 0.0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FFFFFF",
 			"displayColor": "FFFFFF",
 			"displayMaxLineHeight": 0.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"SCROLL_NORMAL"
@@ -424,12 +424,12 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "DOORWAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
@@ -442,7 +442,7 @@
 				"a30fefbc"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -460,7 +460,7 @@
 				"c2956cab"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -479,7 +479,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -498,7 +498,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -517,7 +517,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -536,7 +536,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -555,7 +555,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -574,7 +574,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -593,8 +593,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1000000,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -602,17 +602,153 @@
 			"renderUntilClosingDoorTime": 1,
 			"flashOffTime": 50,
 			"flashOnTime": 50
+		},
+		{
+			"names": [
+				"window_exterior_1/window_exterior_1_left/roof_2",
+				"window_exterior_1/window_exterior_1_left/roof_3",
+				"window_exterior_1/window_exterior_1_left/roof_4",
+				"window_exterior_1/window_exterior_1_left/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_3",
+				"window_exterior_1/window_exterior_1_right/roof_4",
+				"window_exterior_1/window_exterior_1_right/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_6"
+			],
+			"positionDefinitions": [
+				"1c3ab8bd"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_exterior/roof_1",
+				"door_exterior/roof_2",
+				"door_exterior/roof_3",
+				"door_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"5edf39fd"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_2/window_exterior_2_left/roof_1",
+				"window_exterior_2/window_exterior_2_left/roof_2",
+				"window_exterior_2/window_exterior_2_left/roof_3",
+				"window_exterior_2/window_exterior_2_left/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_2",
+				"window_exterior_2/window_exterior_2_right/roof_3",
+				"window_exterior_2/window_exterior_2_right/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"b2528e9b"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_3/window_exterior_3_left/roof_4",
+				"window_exterior_3/window_exterior_3_left/roof_5",
+				"window_exterior_3/window_exterior_3_left/roof_6",
+				"window_exterior_3/window_exterior_3_left/roof_7",
+				"window_exterior_3/window_exterior_3_right/roof_3",
+				"window_exterior_3/window_exterior_3_right/roof_4",
+				"window_exterior_3/window_exterior_3_right/roof_5",
+				"window_exterior_3/window_exterior_3_right/roof_6"
+			],
+			"positionDefinitions": [
+				"9b743d28"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1/window_1_left/roof_4",
+				"window_1/window_1_left/roof_5",
+				"window_1/window_1_left/roof_7",
+				"window_1/window_1_left/roof_8",
+				"window_1/window_1_left/roof_9",
+				"window_1/window_1_right/roof_4",
+				"window_1/window_1_right/roof_5",
+				"window_1/window_1_right/roof_7",
+				"window_1/window_1_right/roof_8",
+				"window_1/window_1_right/roof_9"
+			],
+			"positionDefinitions": [
+				"e5a59b50"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_6",
+				"door/roof_7",
+				"door/roof_8"
+			],
+			"positionDefinitions": [
+				"6d5f8f41"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2/roof_3",
+				"window_2/roof_4",
+				"window_2/roof_6",
+				"window_2/roof_7",
+				"window_2/roof_8"
+			],
+			"positionDefinitions": [
+				"7399bb2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_3/window_3_left/roof_4",
+				"window_3/window_3_left/roof_5",
+				"window_3/window_3_left/roof_7",
+				"window_3/window_3_left/roof_8",
+				"window_3/window_3_left/roof_9",
+				"window_3/window_3_right/roof_4",
+				"window_3/window_3_right/roof_5",
+				"window_3/window_3_right/roof_7",
+				"window_3/window_3_right/roof_8",
+				"window_3/window_3_right/roof_9"
+			],
+			"positionDefinitions": [
+				"bdb196ee"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"2b81b98b"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/sp1900_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/sp1900_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/sp1900_floor.png",
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_cab_2.json
@@ -89,7 +89,7 @@
 				"125cc7c0"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -101,7 +101,7 @@
 				"17e4924b"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -113,7 +113,7 @@
 				"ab310f11"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -125,7 +125,7 @@
 				"cedfc537"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -137,7 +137,7 @@
 				"3757b9f0"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -149,7 +149,7 @@
 				"893ebcd1"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -236,8 +236,8 @@
 				"9b21406"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 0,
 			"renderUntilOpeningDoorTime": 1,
@@ -255,8 +255,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -350,12 +350,12 @@
 				"6a275721"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
+			"displayXPadding": 0,
 			"displayYPadding": 0.2,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 2.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -383,12 +383,12 @@
 				"b8cb2b1d"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
-			"displayMaxLineHeight": 2.0,
-			"displayCjkSizeRatio": 1.0,
+			"displayMaxLineHeight": 2,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [],
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
@@ -403,11 +403,11 @@
 			],
 			"type": "DISPLAY",
 			"displayXPadding": 0.5,
-			"displayYPadding": 0.0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FFFFFF",
 			"displayColor": "FFFFFF",
 			"displayMaxLineHeight": 0.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"SCROLL_NORMAL"
@@ -424,12 +424,12 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "DOORWAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
@@ -442,7 +442,7 @@
 				"59bab839"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -460,7 +460,7 @@
 				"32d3ca9"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -479,7 +479,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -498,7 +498,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -517,7 +517,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -536,7 +536,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -555,7 +555,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -574,7 +574,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -593,8 +593,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1000000,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -602,17 +602,153 @@
 			"renderUntilClosingDoorTime": 1,
 			"flashOffTime": 50,
 			"flashOnTime": 50
+		},
+		{
+			"names": [
+				"window_exterior_1/window_exterior_1_left/roof_2",
+				"window_exterior_1/window_exterior_1_left/roof_3",
+				"window_exterior_1/window_exterior_1_left/roof_4",
+				"window_exterior_1/window_exterior_1_left/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_3",
+				"window_exterior_1/window_exterior_1_right/roof_4",
+				"window_exterior_1/window_exterior_1_right/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_6"
+			],
+			"positionDefinitions": [
+				"22764217"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_exterior/roof_1",
+				"door_exterior/roof_2",
+				"door_exterior/roof_3",
+				"door_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"efd8de2d"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_2/window_exterior_2_left/roof_1",
+				"window_exterior_2/window_exterior_2_left/roof_2",
+				"window_exterior_2/window_exterior_2_left/roof_3",
+				"window_exterior_2/window_exterior_2_left/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_2",
+				"window_exterior_2/window_exterior_2_right/roof_3",
+				"window_exterior_2/window_exterior_2_right/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"1ff8bde3"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_3/window_exterior_3_left/roof_4",
+				"window_exterior_3/window_exterior_3_left/roof_5",
+				"window_exterior_3/window_exterior_3_left/roof_6",
+				"window_exterior_3/window_exterior_3_left/roof_7",
+				"window_exterior_3/window_exterior_3_right/roof_3",
+				"window_exterior_3/window_exterior_3_right/roof_4",
+				"window_exterior_3/window_exterior_3_right/roof_5",
+				"window_exterior_3/window_exterior_3_right/roof_6"
+			],
+			"positionDefinitions": [
+				"9684cd76"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1/window_1_left/roof_4",
+				"window_1/window_1_left/roof_5",
+				"window_1/window_1_left/roof_7",
+				"window_1/window_1_left/roof_8",
+				"window_1/window_1_left/roof_9",
+				"window_1/window_1_right/roof_4",
+				"window_1/window_1_right/roof_5",
+				"window_1/window_1_right/roof_7",
+				"window_1/window_1_right/roof_8",
+				"window_1/window_1_right/roof_9"
+			],
+			"positionDefinitions": [
+				"9a7a0085"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_6",
+				"door/roof_7",
+				"door/roof_8"
+			],
+			"positionDefinitions": [
+				"37ce6be1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2/roof_3",
+				"window_2/roof_4",
+				"window_2/roof_6",
+				"window_2/roof_7",
+				"window_2/roof_8"
+			],
+			"positionDefinitions": [
+				"67db3209"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_3/window_3_left/roof_4",
+				"window_3/window_3_left/roof_5",
+				"window_3/window_3_left/roof_7",
+				"window_3/window_3_left/roof_8",
+				"window_3/window_3_left/roof_9",
+				"window_3/window_3_right/roof_4",
+				"window_3/window_3_right/roof_5",
+				"window_3/window_3_right/roof_7",
+				"window_3/window_3_right/roof_8",
+				"window_3/window_3_right/roof_9"
+			],
+			"positionDefinitions": [
+				"6833760c"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"fa1c9fea"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/sp1900_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/sp1900_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/sp1900_floor.png",
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.25
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_cab_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_cab_1.json
@@ -89,7 +89,7 @@
 				"ca8e1239"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -101,7 +101,7 @@
 				"3fb81a2b"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -113,7 +113,7 @@
 				"9b9d6ddd"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -125,7 +125,7 @@
 				"71c5b115"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -137,7 +137,7 @@
 				"97fd3db"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -149,7 +149,7 @@
 				"8c263012"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -236,8 +236,8 @@
 				"a2736284"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 0,
 			"renderUntilOpeningDoorTime": 1,
@@ -255,8 +255,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -350,12 +350,12 @@
 				"bc8089db"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
+			"displayXPadding": 0,
 			"displayYPadding": 0.2,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 2.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -383,12 +383,12 @@
 				"b0c017ab"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
-			"displayMaxLineHeight": 2.0,
-			"displayCjkSizeRatio": 1.0,
+			"displayMaxLineHeight": 2,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [],
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
@@ -403,11 +403,11 @@
 			],
 			"type": "DISPLAY",
 			"displayXPadding": 0.5,
-			"displayYPadding": 0.0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FFFFFF",
 			"displayColor": "FFFFFF",
 			"displayMaxLineHeight": 0.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"SCROLL_NORMAL"
@@ -424,12 +424,12 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "DOORWAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
@@ -442,7 +442,7 @@
 				"a30fefbc"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -460,7 +460,7 @@
 				"c2956cab"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -479,7 +479,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -498,7 +498,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -517,7 +517,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -536,7 +536,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -555,7 +555,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -574,7 +574,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -593,8 +593,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1000000,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -602,6 +602,142 @@
 			"renderUntilClosingDoorTime": 1,
 			"flashOffTime": 50,
 			"flashOnTime": 50
+		},
+		{
+			"names": [
+				"window_exterior_1/window_exterior_1_left/roof_2",
+				"window_exterior_1/window_exterior_1_left/roof_3",
+				"window_exterior_1/window_exterior_1_left/roof_4",
+				"window_exterior_1/window_exterior_1_left/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_3",
+				"window_exterior_1/window_exterior_1_right/roof_4",
+				"window_exterior_1/window_exterior_1_right/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_6"
+			],
+			"positionDefinitions": [
+				"1c3ab8bd"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_exterior/roof_1",
+				"door_exterior/roof_2",
+				"door_exterior/roof_3",
+				"door_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"5edf39fd"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_2/window_exterior_2_left/roof_1",
+				"window_exterior_2/window_exterior_2_left/roof_2",
+				"window_exterior_2/window_exterior_2_left/roof_3",
+				"window_exterior_2/window_exterior_2_left/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_2",
+				"window_exterior_2/window_exterior_2_right/roof_3",
+				"window_exterior_2/window_exterior_2_right/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"b2528e9b"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_3/window_exterior_3_left/roof_4",
+				"window_exterior_3/window_exterior_3_left/roof_5",
+				"window_exterior_3/window_exterior_3_left/roof_6",
+				"window_exterior_3/window_exterior_3_left/roof_7",
+				"window_exterior_3/window_exterior_3_right/roof_3",
+				"window_exterior_3/window_exterior_3_right/roof_4",
+				"window_exterior_3/window_exterior_3_right/roof_5",
+				"window_exterior_3/window_exterior_3_right/roof_6"
+			],
+			"positionDefinitions": [
+				"9b743d28"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1/window_1_left/roof_4",
+				"window_1/window_1_left/roof_5",
+				"window_1/window_1_left/roof_7",
+				"window_1/window_1_left/roof_8",
+				"window_1/window_1_left/roof_9",
+				"window_1/window_1_right/roof_4",
+				"window_1/window_1_right/roof_5",
+				"window_1/window_1_right/roof_7",
+				"window_1/window_1_right/roof_8",
+				"window_1/window_1_right/roof_9"
+			],
+			"positionDefinitions": [
+				"e5a59b50"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_6",
+				"door/roof_7",
+				"door/roof_8"
+			],
+			"positionDefinitions": [
+				"6d5f8f41"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2/roof_3",
+				"window_2/roof_4",
+				"window_2/roof_6",
+				"window_2/roof_7",
+				"window_2/roof_8"
+			],
+			"positionDefinitions": [
+				"7399bb2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_3/window_3_left/roof_4",
+				"window_3/window_3_left/roof_5",
+				"window_3/window_3_left/roof_7",
+				"window_3/window_3_left/roof_8",
+				"window_3/window_3_left/roof_9",
+				"window_3/window_3_right/roof_4",
+				"window_3/window_3_right/roof_5",
+				"window_3/window_3_right/roof_7",
+				"window_3/window_3_right/roof_8",
+				"window_3/window_3_right/roof_9"
+			],
+			"positionDefinitions": [
+				"bdb196ee"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"2b81b98b"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 0.5,
@@ -611,7 +747,7 @@
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
 	"gangwayYOffset": 0.5,
 	"gangwayZOffset": 0.25

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_cab_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_cab_2.json
@@ -89,7 +89,7 @@
 				"125cc7c0"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -101,7 +101,7 @@
 				"17e4924b"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -113,7 +113,7 @@
 				"ab310f11"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -125,7 +125,7 @@
 				"cedfc537"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
+			"doorXMultiplier": 1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -137,7 +137,7 @@
 				"3757b9f0"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -149,7 +149,7 @@
 				"893ebcd1"
 			],
 			"renderStage": "INTERIOR",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2"
 		},
@@ -236,8 +236,8 @@
 				"9b21406"
 			],
 			"renderStage": "EXTERIOR",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 0,
 			"renderUntilOpeningDoorTime": 1,
@@ -255,8 +255,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -350,12 +350,12 @@
 				"6a275721"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
+			"displayXPadding": 0,
 			"displayYPadding": 0.2,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 2.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -383,12 +383,12 @@
 				"b8cb2b1d"
 			],
 			"type": "DISPLAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
-			"displayMaxLineHeight": 2.0,
-			"displayCjkSizeRatio": 1.0,
+			"displayMaxLineHeight": 2,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [],
 			"displayPadZeros": 3,
 			"displayType": "DEPARTURE_INDEX",
@@ -403,11 +403,11 @@
 			],
 			"type": "DISPLAY",
 			"displayXPadding": 0.5,
-			"displayYPadding": 0.0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FFFFFF",
 			"displayColor": "FFFFFF",
 			"displayMaxLineHeight": 0.5,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"SINGLE_LINE",
 				"SCROLL_NORMAL"
@@ -424,12 +424,12 @@
 			],
 			"renderStage": "EXTERIOR",
 			"type": "DOORWAY",
-			"displayXPadding": 0.0,
-			"displayYPadding": 0.0,
+			"displayXPadding": 0,
+			"displayYPadding": 0,
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.5,
-			"displayCjkSizeRatio": 2.0,
+			"displayCjkSizeRatio": 2,
 			"displayOptions": [],
 			"displayType": "DESTINATION",
 			"displayDefaultText": "Not In Service"
@@ -442,7 +442,7 @@
 				"59bab839"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -460,7 +460,7 @@
 				"32d3ca9"
 			],
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 0,
@@ -479,7 +479,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -498,7 +498,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 3000,
@@ -517,7 +517,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -536,7 +536,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1000000,
@@ -555,7 +555,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": 10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -574,7 +574,7 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": -1.0,
+			"doorXMultiplier": -1,
 			"doorZMultiplier": -10.5,
 			"doorAnimationType": "PLUG_SLOW_2",
 			"renderFromOpeningDoorTime": 1,
@@ -593,8 +593,8 @@
 			],
 			"condition": "DOORS_OPENED",
 			"renderStage": "ALWAYS_ON_LIGHT",
-			"doorXMultiplier": 1.0,
-			"doorZMultiplier": 0.0,
+			"doorXMultiplier": 1,
+			"doorZMultiplier": 0,
 			"doorAnimationType": "STANDARD",
 			"renderFromOpeningDoorTime": 1000000,
 			"renderUntilOpeningDoorTime": 1000000,
@@ -602,6 +602,142 @@
 			"renderUntilClosingDoorTime": 1,
 			"flashOffTime": 50,
 			"flashOnTime": 50
+		},
+		{
+			"names": [
+				"window_exterior_1/window_exterior_1_left/roof_2",
+				"window_exterior_1/window_exterior_1_left/roof_3",
+				"window_exterior_1/window_exterior_1_left/roof_4",
+				"window_exterior_1/window_exterior_1_left/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_3",
+				"window_exterior_1/window_exterior_1_right/roof_4",
+				"window_exterior_1/window_exterior_1_right/roof_5",
+				"window_exterior_1/window_exterior_1_right/roof_6"
+			],
+			"positionDefinitions": [
+				"22764217"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door_exterior/roof_1",
+				"door_exterior/roof_2",
+				"door_exterior/roof_3",
+				"door_exterior/roof_4"
+			],
+			"positionDefinitions": [
+				"efd8de2d"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_2/window_exterior_2_left/roof_1",
+				"window_exterior_2/window_exterior_2_left/roof_2",
+				"window_exterior_2/window_exterior_2_left/roof_3",
+				"window_exterior_2/window_exterior_2_left/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_2",
+				"window_exterior_2/window_exterior_2_right/roof_3",
+				"window_exterior_2/window_exterior_2_right/roof_4",
+				"window_exterior_2/window_exterior_2_right/roof_5"
+			],
+			"positionDefinitions": [
+				"1ff8bde3"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_exterior_3/window_exterior_3_left/roof_4",
+				"window_exterior_3/window_exterior_3_left/roof_5",
+				"window_exterior_3/window_exterior_3_left/roof_6",
+				"window_exterior_3/window_exterior_3_left/roof_7",
+				"window_exterior_3/window_exterior_3_right/roof_3",
+				"window_exterior_3/window_exterior_3_right/roof_4",
+				"window_exterior_3/window_exterior_3_right/roof_5",
+				"window_exterior_3/window_exterior_3_right/roof_6"
+			],
+			"positionDefinitions": [
+				"9684cd76"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_1/window_1_left/roof_4",
+				"window_1/window_1_left/roof_5",
+				"window_1/window_1_left/roof_7",
+				"window_1/window_1_left/roof_8",
+				"window_1/window_1_left/roof_9",
+				"window_1/window_1_right/roof_4",
+				"window_1/window_1_right/roof_5",
+				"window_1/window_1_right/roof_7",
+				"window_1/window_1_right/roof_8",
+				"window_1/window_1_right/roof_9"
+			],
+			"positionDefinitions": [
+				"9a7a0085"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"door/roof_6",
+				"door/roof_7",
+				"door/roof_8"
+			],
+			"positionDefinitions": [
+				"37ce6be1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_2/roof_3",
+				"window_2/roof_4",
+				"window_2/roof_6",
+				"window_2/roof_7",
+				"window_2/roof_8"
+			],
+			"positionDefinitions": [
+				"67db3209"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_3/window_3_left/roof_4",
+				"window_3/window_3_left/roof_5",
+				"window_3/window_3_left/roof_7",
+				"window_3/window_3_left/roof_8",
+				"window_3/window_3_left/roof_9",
+				"window_3/window_3_right/roof_4",
+				"window_3/window_3_right/roof_5",
+				"window_3/window_3_right/roof_7",
+				"window_3/window_3_right/roof_8",
+				"window_3/window_3_right/roof_9"
+			],
+			"positionDefinitions": [
+				"6833760c"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"fa1c9fea"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 0.5,
@@ -611,7 +747,7 @@
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
 	"gangwayYOffset": 0.5,
 	"gangwayZOffset": 0.25

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_low_floor_trailer.json
@@ -77,7 +77,7 @@
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.2,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -110,7 +110,7 @@
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.2,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -129,6 +129,47 @@
 			"displayXPadding": 0.3,
 			"displayYPadding": 0.3,
 			"displayType": "ROUTE_COLOR"
+		},
+		{
+			"names": [
+				"window_exterior_4/roof_2",
+				"window_exterior_4/roof_3",
+				"window_exterior_4/roof_4",
+				"window_exterior_4/roof_5"
+			],
+			"positionDefinitions": [
+				"b20d0645"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_4/roof_5",
+				"window_4/roof_6",
+				"window_4/roof_8",
+				"window_4/roof_9",
+				"window_4/roof_10"
+			],
+			"positionDefinitions": [
+				"9d6887a2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"7d74e4cc"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 0.5,
@@ -138,7 +179,7 @@
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
 	"gangwayYOffset": 0.5,
 	"gangwayZOffset": 0.375

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_trailer.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s700_trailer.json
@@ -77,7 +77,7 @@
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.2,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -110,7 +110,7 @@
 			"displayColorCjk": "FF9900",
 			"displayColor": "FF9900",
 			"displayMaxLineHeight": 1.2,
-			"displayCjkSizeRatio": 1.0,
+			"displayCjkSizeRatio": 1,
 			"displayOptions": [
 				"UPPER_CASE",
 				"CYCLE_LANGUAGES"
@@ -129,17 +129,58 @@
 			"displayXPadding": 0.3,
 			"displayYPadding": 0.3,
 			"displayType": "ROUTE_COLOR"
+		},
+		{
+			"names": [
+				"window_exterior_4/roof_2",
+				"window_exterior_4/roof_3",
+				"window_exterior_4/roof_4",
+				"window_exterior_4/roof_5"
+			],
+			"positionDefinitions": [
+				"b20d0645"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"window_4/roof_5",
+				"window_4/roof_6",
+				"window_4/roof_8",
+				"window_4/roof_9",
+				"window_4/roof_10"
+			],
+			"positionDefinitions": [
+				"9d6887a2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/end_exterior_left/roof_4",
+				"end_exterior/end_exterior_left/roof_5",
+				"end_exterior/end_exterior_left/roof_6",
+				"end_exterior/end_exterior_left/roof_7",
+				"end_exterior/end_exterior_right/roof_5",
+				"end_exterior/end_exterior_right/roof_6",
+				"end_exterior/end_exterior_right/roof_7",
+				"end_exterior/end_exterior_right/roof_8"
+			],
+			"positionDefinitions": [
+				"7d74e4cc"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
-	"modelYOffset": 1.0,
+	"modelYOffset": 1,
 	"gangwayInnerSideResource": "mtr:textures/gangway/sp1900_side.png",
 	"gangwayInnerTopResource": "mtr:textures/gangway/sp1900_roof.png",
 	"gangwayInnerBottomResource": "mtr:textures/gangway/sp1900_floor.png",
 	"gangwayOuterSideResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterTopResource": "mtr:textures/gangway/sp1900_exterior.png",
 	"gangwayOuterBottomResource": "mtr:textures/gangway/sp1900_exterior.png",
-	"gangwayWidth": 2.0,
+	"gangwayWidth": 2,
 	"gangwayHeight": 2.25,
-	"gangwayYOffset": 1.0,
+	"gangwayYOffset": 1,
 	"gangwayZOffset": 0.375
 }

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_common.json
@@ -300,6 +300,54 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_window"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped",
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_common.json
@@ -348,6 +348,34 @@
 				"doorEnd2Flipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_window_light"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"windowEnd1",
+				"windowEnd2",
+				"windowEnd1Flipped",
+				"windowEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_door_light"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped",
+				"doorEnd1",
+				"doorEnd2",
+				"doorEnd1Flipped",
+				"doorEnd2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_1.json
@@ -37,6 +37,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_1.json
@@ -55,6 +55,15 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_2.json
@@ -55,6 +55,15 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_end_2.json
@@ -37,6 +37,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_1.json
@@ -82,6 +82,23 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof/outer_roof_7",
+				"head_exterior/roof/outer_roof_6",
+				"head_exterior/roof/outer_roof_5",
+				"head_exterior/roof/outer_roof_8",
+				"head_exterior/roof/vent_1",
+				"head_exterior/roof/vent_2",
+				"head_exterior/roof/vent_top",
+				"head_exterior/roof/outer_roof_3",
+				"head_exterior/roof/outer_roof_4"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_1.json
@@ -73,6 +73,15 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_2.json
@@ -73,6 +73,15 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/s_train_head_2.json
@@ -82,6 +82,23 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/roof/outer_roof_7",
+				"head_exterior/roof/outer_roof_6",
+				"head_exterior/roof/outer_roof_5",
+				"head_exterior/roof/outer_roof_8",
+				"head_exterior/roof/vent_1",
+				"head_exterior/roof/vent_2",
+				"head_exterior/roof/vent_top",
+				"head_exterior/roof/outer_roof_3",
+				"head_exterior/roof/outer_roof_4"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_common.json
@@ -264,6 +264,46 @@
 			],
 			"condition": "DOORS_CLOSED",
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_sp1900"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_sp1900"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_exterior"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_common.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_common.json
@@ -304,6 +304,18 @@
 				"doorFlipped"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_light_sp1900"
+			],
+			"positionDefinitions": [
+				"window",
+				"windowFlipped",
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1,

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_door_top_overlay.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_door_top_overlay.json
@@ -9,6 +9,16 @@
 				"doorFlipped"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"outer_roof"
+			],
+			"positionDefinitions": [
+				"door",
+				"doorFlipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_1.json
@@ -47,6 +47,24 @@
 				"end1"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_sp1900"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_1.json
@@ -65,6 +65,25 @@
 				"end1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_sp1900"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/outer_roof_1",
+				"end_exterior/outer_roof_2"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_2.json
@@ -65,6 +65,25 @@
 				"end2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_sp1900"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"end_exterior/outer_roof_1",
+				"end_exterior/outer_roof_2"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_end_2.json
@@ -47,6 +47,24 @@
 				"end2"
 			],
 			"renderStage": "EXTERIOR"
+		},
+		{
+			"names": [
+				"roof_end_sp1900"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_1.json
@@ -135,6 +135,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_sp1900"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"roofHead1"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_1.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_1.json
@@ -153,6 +153,41 @@
 				"roofHead1"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_sp1900"
+			],
+			"positionDefinitions": [
+				"end1"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/roof_corner_2_r1",
+				"head_exterior/front/roof_corner_1_r1",
+				"head_exterior/front/roof_middle_corner_2_r1",
+				"head_exterior/front/roof_middle_corner_1_r1",
+				"head_exterior/front/roof_side_2_r1",
+				"head_exterior/front/roof_side_1_r1"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_roof",
+				"head_exterior/outer_roof_2",
+				"head_exterior/outer_roof_1",
+				"head_exterior/front/front_roof_r1"
+			],
+			"positionDefinitions": [
+				"end1Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_2.json
@@ -153,6 +153,41 @@
 				"roofHead2"
 			],
 			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_light_sp1900"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/front/roof_corner_2_r1",
+				"head_exterior/front/roof_corner_1_r1",
+				"head_exterior/front/roof_middle_corner_2_r1",
+				"head_exterior/front/roof_middle_corner_1_r1",
+				"head_exterior/front/roof_side_2_r1",
+				"head_exterior/front/roof_side_1_r1"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"head_exterior/driver_roof",
+				"head_exterior/outer_roof_2",
+				"head_exterior/outer_roof_1",
+				"head_exterior/front/front_roof_r1"
+			],
+			"positionDefinitions": [
+				"end2Flipped"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_2.json
+++ b/fabric/src/main/resources/assets/mtr/properties/vehicle/sp1900_head_2.json
@@ -135,6 +135,24 @@
 			],
 			"condition": "AT_DEPOT",
 			"renderStage": "ALWAYS_ON_LIGHT"
+		},
+		{
+			"names": [
+				"roof_end_sp1900"
+			],
+			"positionDefinitions": [
+				"end2"
+			],
+			"type": "WEATHER_COVER"
+		},
+		{
+			"names": [
+				"roof_end_exterior"
+			],
+			"positionDefinitions": [
+				"roofHead2"
+			],
+			"type": "WEATHER_COVER"
 		}
 	],
 	"modelYOffset": 1

--- a/fabric/src/main/resources/mtr.mixins.json
+++ b/fabric/src/main/resources/mtr.mixins.json
@@ -9,7 +9,9 @@
 	],
 	"client": [
 		"ClientWorldRenderingMixin",
-		"PlayerRendererOffsetMixin"
+		"EntityRainMixin",
+		"PlayerRendererOffsetMixin",
+		"WorldRendererWeatherMixin"
 	],
 	"server": [],
 	"injectors": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -22,6 +22,9 @@ minecraft {
 }
 
 sourceSets.main.resources { srcDir "src/generated/resources" }
+if (!buildTools.hasJadeSupport()) {
+	sourceSets.main.java.exclude "org/mtr/init/JadeConfig.java"
+}
 
 dependencies {
 	minecraft "net.minecraftforge:forge:${minecraftVersion}-${buildTools.getForgeVersion()}"

--- a/forge/src/main/resources/mtr.mixins.json
+++ b/forge/src/main/resources/mtr.mixins.json
@@ -9,7 +9,9 @@
 	],
 	"client": [
 		"ClientWorldRenderingMixin",
-		"PlayerRendererOffsetMixin"
+		"EntityRainMixin",
+		"PlayerRendererOffsetMixin",
+		"WorldRendererWeatherMixin"
 	],
 	"server": [],
 	"injectors": {

--- a/website/src/app/component/edit-vehicle-model-part/edit-vehicle-model-part.dialog.html
+++ b/website/src/app/component/edit-vehicle-model-part/edit-vehicle-model-part.dialog.html
@@ -32,6 +32,8 @@
 				<mat-option value="DISPLAY">Display</mat-option>
 				<mat-option value="FLOOR">Floor</mat-option>
 				<mat-option value="DOORWAY">Doorway</mat-option>
+				<mat-option value="WEATHER_COVER">Weather Cover</mat-option>
+				<mat-option value="WEATHER_COVER_FLOOR">Weather Cover Floor</mat-option>
 				<mat-option value="SEAT">Seat</mat-option>
 			</mat-select>
 		</mat-form-field>

--- a/website/src/app/component/edit-vehicle-model-parts/edit-vehicle-model-parts.dialog.html
+++ b/website/src/app/component/edit-vehicle-model-parts/edit-vehicle-model-parts.dialog.html
@@ -27,16 +27,16 @@
 <mat-dialog-actions>
 	<form class="row gap center wide" [formGroup]="formGroup">
 		<div class="spacing"></div>
-		@if (hasNormal && (hasFloorOrDoorway || hasSeat || hasDisplay)) {
+		@if (hasNormal && (hasFloorDoorwayOrWeatherCover || hasSeat || hasDisplay)) {
 			<mat-checkbox (change)="filterData()" formControlName="showNormalParts">Show Normal Parts</mat-checkbox>
 		}
-		@if (hasFloorOrDoorway && (hasNormal || hasSeat || hasDisplay)) {
-			<mat-checkbox (change)="filterData()" formControlName="showFloorsAndDoorways">Show Floors and Doorways</mat-checkbox>
+		@if (hasFloorDoorwayOrWeatherCover && (hasNormal || hasSeat || hasDisplay)) {
+			<mat-checkbox (change)="filterData()" formControlName="showFloorsAndDoorways">Show Floors, Doorways, and Weather Covers</mat-checkbox>
 		}
-		@if (hasSeat && (hasNormal || hasFloorOrDoorway || hasDisplay)) {
+		@if (hasSeat && (hasNormal || hasFloorDoorwayOrWeatherCover || hasDisplay)) {
 			<mat-checkbox (change)="filterData()" formControlName="showSeats">Show Seats</mat-checkbox>
 		}
-		@if (hasDisplay && (hasNormal || hasFloorOrDoorway || hasSeat)) {
+		@if (hasDisplay && (hasNormal || hasFloorDoorwayOrWeatherCover || hasSeat)) {
 			<mat-checkbox (change)="filterData()" formControlName="showDisplays">Show Displays</mat-checkbox>
 		}
 		<div>

--- a/website/src/app/component/edit-vehicle-model-parts/edit-vehicle-model-parts.dialog.ts
+++ b/website/src/app/component/edit-vehicle-model-parts/edit-vehicle-model-parts.dialog.ts
@@ -84,7 +84,7 @@ export class EditVehicleModelPartsDialog {
 	protected readonly dataSource: ModelPropertiesPartWrapperDTO[] = [];
 	protected readonly formGroup;
 	protected hasNormal = false;
-	protected hasFloorOrDoorway = false;
+	protected hasFloorDoorwayOrWeatherCover = false;
 	protected hasSeat = false;
 	protected hasDisplay = false;
 
@@ -102,7 +102,7 @@ export class EditVehicleModelPartsDialog {
 	filterData() {
 		this.dataSource.length = 0;
 		this.hasNormal = false;
-		this.hasFloorOrDoorway = false;
+		this.hasFloorDoorwayOrWeatherCover = false;
 		this.hasSeat = false;
 		this.hasDisplay = false;
 		let showDoorColumns = false;
@@ -111,9 +111,9 @@ export class EditVehicleModelPartsDialog {
 		this.data.model.parts.forEach(modelPropertiesPart => {
 			if (this.modelPartNames.includes(modelPropertiesPart.positionDefinition.name)) {
 				const isNormal = modelPropertiesPart.type === "NORMAL";
-				const isFloorOrDoorway = modelPropertiesPart.type === "FLOOR" || modelPropertiesPart.type === "DOORWAY";
+				const isFloorDoorwayOrWeatherCover = modelPropertiesPart.type === "FLOOR" || modelPropertiesPart.type === "DOORWAY" || modelPropertiesPart.type === "WEATHER_COVER" || modelPropertiesPart.type === "WEATHER_COVER_FLOOR";
 				const isSeat = modelPropertiesPart.type === "SEAT";
-				if (isNormal && newData.showNormalParts || isFloorOrDoorway && newData.showFloorsAndDoorways || isSeat && newData.showSeats || isDisplay(modelPropertiesPart) && newData.showDisplays) {
+				if (isNormal && newData.showNormalParts || isFloorDoorwayOrWeatherCover && newData.showFloorsAndDoorways || isSeat && newData.showSeats || isDisplay(modelPropertiesPart) && newData.showDisplays) {
 					this.dataSource.push(modelPropertiesPart);
 					if (hasDoorMultiplier(modelPropertiesPart)) {
 						showDoorColumns = true;
@@ -125,8 +125,8 @@ export class EditVehicleModelPartsDialog {
 				if (isNormal) {
 					this.hasNormal = true;
 				}
-				if (isFloorOrDoorway) {
-					this.hasFloorOrDoorway = true;
+				if (isFloorDoorwayOrWeatherCover) {
+					this.hasFloorDoorwayOrWeatherCover = true;
 				}
 				if (isSeat) {
 					this.hasSeat = true;


### PR DESCRIPTION
## Summary

This PR adds vehicle weather cover support for rain handling.（#337）

Vehicle resources can now mark roof parts as weather covers. When a player is standing under those marked areas, rain particles will no longer fall , and rain sound will be reduced.

## Changes

- Added weather cover metadata support for vehicle parts.
- Marked built-in vehicle roof parts as weather covers.
- Applied weather cover checks to client rain exposure handling.
- Filtered rain particles under covered vehicle areas.
- Reduced rain sound volume while the player is under vehicle weather cover.
- Added brush outline rendering for weather cover areas.
- Fixed generated Fabric and Forge mixins across the supported Minecraft version matrix.
- Added shared player-position weather cover checking for older weather APIs.
- Set Javadoc encoding to UTF-8.

<img width="2560" height="1351" alt="2026-06-22_09 44 24" src="https://github.com/user-attachments/assets/7b4b7708-e451-4dce-b623-e20e47646515" />
