### PR TITLE
[4.1] Customizable run sound index

### DIFF
--- a/buildSrc/src/main/resources/schema/resource/railResource.json
+++ b/buildSrc/src/main/resources/schema/resource/railResource.json
@@ -32,6 +32,11 @@
 		},
 		"modelYOffset": {
 			"type": "number"
+		},
+		"soundIndex": {
+			"type": "number",
+			"minimum": 0,
+			"maximum": 1000
 		}
 	},
 	"required": [
@@ -42,6 +47,7 @@
 		"textureResource",
 		"flipTextureV",
 		"repeatInterval",
-		"modelYOffset"
+		"modelYOffset",
+		"soundIndex"
 	]
 }

--- a/src/main/java/org/mtr/client/CustomResourceLoader.java
+++ b/src/main/java/org/mtr/client/CustomResourceLoader.java
@@ -314,8 +314,13 @@ public class CustomResourceLoader {
 		return new ObjectImmutableList<>(RAILS);
 	}
 
+	@Nullable
+	public static RailResource getRailById(String railId) {
+		return RAILS_CACHE.get(railId);
+	}
+
 	public static void getRailById(String railId, Consumer<RailResource> ifPresent) {
-		final RailResource railResource = RAILS_CACHE.get(railId);
+		final RailResource railResource = getRailById(railId);
 		if (railResource != null) {
 			ifPresent.accept(railResource);
 		}

--- a/src/main/java/org/mtr/data/PersistentVehicleData.java
+++ b/src/main/java/org/mtr/data/PersistentVehicleData.java
@@ -5,10 +5,8 @@ import net.minecraft.core.BlockPos;
 import org.jspecify.annotations.Nullable;
 import org.mtr.client.Oscillation;
 import org.mtr.client.ScrollingText;
-import org.mtr.core.data.TransportMode;
-import org.mtr.core.data.Vehicle;
-import org.mtr.core.data.VehicleCar;
-import org.mtr.core.data.VehicleExtraData;
+import org.mtr.core.data.*;
+import org.mtr.core.tool.Utilities;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import org.mtr.resource.VehicleResource;
@@ -32,6 +30,7 @@ public final class PersistentVehicleData {
 	private final ObjectArrayList<VehicleSoundBase> vehicleSoundBaseList = new ObjectArrayList<>();
 	private final ObjectArrayList<ObjectArrayList<ScrollingText>> scrollingTexts = new ObjectArrayList<>();
 	private final ObjectArrayList<Oscillation> oscillations = new ObjectArrayList<>();
+	private final ObjectArrayList<VehicleSoundBase.RunSoundInfo> runSoundStates = new ObjectArrayList<>();
 
 	public PersistentVehicleData(ObjectImmutableList<VehicleCar> immutableVehicleCars, TransportMode transportMode) {
 		longestDimensions = new double[immutableVehicleCars.size()];
@@ -92,6 +91,21 @@ public final class PersistentVehicleData {
 			nextAnnouncementRailProgress = railProgress + vehicleExtraData.getTotalVehicleLength() * 1.5;
 		}
 		oscillations.forEach(oscillation -> oscillation.tick(millisElapsed));
+
+		runSoundStates.clear();
+		double headRailProgress = railProgress;
+		for(int i = 0; i < vehicleExtraData.immutableVehicleCars.size(); i++) {
+			final double carLength = vehicleExtraData.immutableVehicleCars.get(i).getLength();
+			final double tailRailProgress = headRailProgress - carLength;
+
+			final int thisPathIndex = Utilities.getIndexFromConditionalList(vehicleExtraData.immutablePath, headRailProgress);
+			final int lastPathIndex = Utilities.getIndexFromConditionalList(vehicleExtraData.immutablePath, tailRailProgress);
+			final PathData thisPathData = Utilities.getElement(vehicleExtraData.immutablePath, thisPathIndex);
+			final PathData lastPathData = thisPathIndex == lastPathIndex ? thisPathData : Utilities.getElement(vehicleExtraData.immutablePath, lastPathIndex);
+			float pathDelta = thisPathIndex == lastPathIndex ? 1 : (float)Math.min(1, (headRailProgress - lastPathData.getEndDistance()) / carLength);
+			runSoundStates.add(VehicleSoundBase.RunSoundInfo.create(lastPathData.getRail(), thisPathData.getRail(), pathDelta));
+			headRailProgress -= vehicleExtraData.immutableVehicleCars.get(i).getLength();
+		}
 	}
 
 	public boolean checkCanOpenDoors() {
@@ -118,8 +132,9 @@ public final class PersistentVehicleData {
 		return oldRailProgress < nextAnnouncementRailProgress && railProgress >= nextAnnouncementRailProgress;
 	}
 
-	public void playMotorSound(VehicleResource vehicleResource, int carNumber, BlockPos bogiePosition, float speed, float speedChange, float acceleration, boolean isOnRoute) {
-		getVehicleSoundBase(vehicleResource, carNumber).playMotorSound(bogiePosition, speed, speedChange, acceleration, isOnRoute);
+	public void playVehicleSound(VehicleResource vehicleResource, int carNumber, BlockPos bogiePosition, float speed, float speedChange, float acceleration, boolean isOnRoute) {
+		VehicleSoundBase.RunSoundInfo pathProgress = runSoundStates.size() >= carNumber ? runSoundStates.get(carNumber) : null;
+		getVehicleSoundBase(vehicleResource, carNumber).playVehicleSound(new VehicleSoundBase.VehicleSoundParameters(pathProgress, bogiePosition, speed, speedChange, acceleration, isOnRoute));
 	}
 
 	public void playDoorSound(VehicleResource vehicleResource, int carNumber, BlockPos vehiclePosition) {

--- a/src/main/java/org/mtr/data/VehicleExtension.java
+++ b/src/main/java/org/mtr/data/VehicleExtension.java
@@ -302,8 +302,8 @@ public class VehicleExtension extends Vehicle implements Utilities {
 		return vehicleCarsAndPositions;
 	}
 
-	public void playMotorSound(VehicleResource vehicleResource, int carNumber, Vector bogiePosition) {
-		persistentVehicleData.playMotorSound(vehicleResource, carNumber, BlockPos.containing(bogiePosition.x(), bogiePosition.y(), bogiePosition.z()), (float) speed, (float) (speed - oldSpeed), (float) vehicleExtraData.getAcceleration(), getIsOnRoute());
+	public void playVehicleSound(VehicleResource vehicleResource, int carNumber, Vector bogiePosition) {
+		persistentVehicleData.playVehicleSound(vehicleResource, carNumber, BlockPos.containing(bogiePosition.x(), bogiePosition.y(), bogiePosition.z()), (float) speed, (float) (speed - oldSpeed), (float) vehicleExtraData.getAcceleration(), getIsOnRoute());
 	}
 
 	public void playDoorSound(VehicleResource vehicleResource, int carNumber, Vector vehiclePosition) {

--- a/src/main/java/org/mtr/render/RenderLifts.java
+++ b/src/main/java/org/mtr/render/RenderLifts.java
@@ -143,8 +143,8 @@ public class RenderLifts implements IGui {
 				final boolean doorway1Open;
 				final boolean doorway2Open;
 				if (lift.hasCoolDown()) {
-					doorway1Open = RenderVehicleHelper.canOpenDoors(doorway1, absolutePositionAndRotation, Math.min(lift.getDoorValue(), LIFT_DOOR_VALUE));
-					doorway2Open = lift.getIsDoubleSided() && RenderVehicleHelper.canOpenDoors(doorway2, absolutePositionAndRotation, Math.min(lift.getDoorValue(), LIFT_DOOR_VALUE));
+					doorway1Open = RenderVehicleHelper.checkAndOpenNearbyDoors(doorway1, absolutePositionAndRotation, Math.min(lift.getDoorValue(), LIFT_DOOR_VALUE));
+					doorway2Open = lift.getIsDoubleSided() && RenderVehicleHelper.checkAndOpenNearbyDoors(doorway2, absolutePositionAndRotation, Math.min(lift.getDoorValue(), LIFT_DOOR_VALUE));
 					if (doorway1Open) {
 						openDoorways.add(doorway1);
 					}

--- a/src/main/java/org/mtr/render/RenderVehicleHelper.java
+++ b/src/main/java/org/mtr/render/RenderVehicleHelper.java
@@ -11,11 +11,14 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 import org.mtr.block.BlockPSDAPGDoorBase;
 import org.mtr.block.PlatformHelper;
 import org.mtr.client.IDrawing;
 import org.mtr.core.tool.Utilities;
 import org.mtr.registry.Items;
+
+import java.util.function.Consumer;
 
 public class RenderVehicleHelper {
 
@@ -25,9 +28,9 @@ public class RenderVehicleHelper {
 	private static final double RIDE_STEP_THRESHOLD = 0.75;
 
 	/**
-	 * @return whether the doorway is close to platform blocks, unlocked platform screen doors, or unlocked automatic platform gates
+	 * @return Whether the doorway is close to platform blocks, unlocked platform screen doors, or unlocked automatic platform gates
 	 */
-	public static boolean canOpenDoors(AABB doorway, PositionAndRotation positionAndRotation, double doorValue) {
+	public static boolean canOpenDoors(AABB doorway, PositionAndRotation positionAndRotation, @Nullable Consumer<BlockPSDAPGDoorBase.BlockEntityBase> doorBlockEntityCallback) {
 		final ClientLevel clientWorld = Minecraft.getInstance().level;
 		if (clientWorld == null) {
 			return false;
@@ -55,9 +58,11 @@ public class RenderVehicleHelper {
 						canOpenDoors = true;
 					} else if (block instanceof BlockPSDAPGDoorBase && blockState.getValue(BlockPSDAPGDoorBase.UNLOCKED)) {
 						canOpenDoors = true;
+						if(doorBlockEntityCallback == null) break;
+
 						final BlockEntity blockEntity = clientWorld.getBlockEntity(checkPos);
-						if (blockEntity instanceof BlockPSDAPGDoorBase.BlockEntityBase) {
-							((BlockPSDAPGDoorBase.BlockEntityBase) blockEntity).setDoorValue(doorValue);
+						if (blockEntity instanceof BlockPSDAPGDoorBase.BlockEntityBase doorBlockEntity) {
+							doorBlockEntityCallback.accept(doorBlockEntity);
 						}
 					}
 				}
@@ -65,6 +70,16 @@ public class RenderVehicleHelper {
 		}
 
 		return canOpenDoors;
+	}
+
+	/**
+	 * Attempts to open platform doors nearby the doorway by the given doorValue.
+	 * @return Whether the doorway is close to platform blocks, unlocked platform screen doors, or unlocked automatic platform gates
+	 */
+	public static boolean checkAndOpenNearbyDoors(AABB doorway, PositionAndRotation positionAndRotation, double doorValue) {
+		return canOpenDoors(doorway, positionAndRotation, (blockEntity) -> {
+			blockEntity.setDoorValue(doorValue);
+		});
 	}
 
 	public static double getDoorBlockedAmount(AABB doorway, double playerX, double playerY, double playerZ) {

--- a/src/main/java/org/mtr/render/RenderVehicles.java
+++ b/src/main/java/org/mtr/render/RenderVehicles.java
@@ -149,7 +149,7 @@ public final class RenderVehicles {
 					} else if (vehicleResourceCache == null || !vehicle.getTransportMode().continuousMovement && vehicle.isMoving() || !vehicle.persistentVehicleData.checkCanOpenDoors()) {
 						openDoorways = new ObjectArrayList<>();
 					} else {
-						openDoorways = vehicleResourceCache.doorways.stream().filter(doorway -> RenderVehicleHelper.canOpenDoors(doorway, absoluteVehicleCarPositionAndRotation, vehicle.persistentVehicleData.getDoorValue())).collect(Collectors.toCollection(ObjectArrayList::new));
+						openDoorways = vehicleResourceCache.doorways.stream().filter(doorway -> RenderVehicleHelper.checkAndOpenNearbyDoors(doorway, absoluteVehicleCarPositionAndRotation, vehicle.persistentVehicleData.getDoorValue())).collect(Collectors.toCollection(ObjectArrayList::new));
 					}
 					final double oscillationAmount = vehicle.persistentVehicleData.getOscillation(carNumber).getAmount() * Config.getClient().getVehicleOscillationMultiplier();
 
@@ -183,7 +183,7 @@ public final class RenderVehicles {
 					}
 
 					// Play vehicle sounds
-					vehicle.playMotorSound(vehicleResource, carNumber, absoluteVehicleCarPositionAndRotation.position);
+					vehicle.playVehicleSound(vehicleResource, carNumber, absoluteVehicleCarPositionAndRotation.position);
 
 					// Play door sound
 					if (!openDoorways.isEmpty()) {

--- a/src/main/java/org/mtr/resource/RailResource.java
+++ b/src/main/java/org/mtr/resource/RailResource.java
@@ -30,7 +30,7 @@ public final class RailResource extends RailResourceSchema implements StoredMode
 	 * Used to create the default rail
 	 */
 	public RailResource(String id, String name, ResourceProvider resourceProvider) {
-		super(id, name, "777777", "", "", false, 0, 0, resourceProvider);
+		super(id, name, "777777", "", "", false, 0, 0, 0, resourceProvider);
 		shouldPreload = false;
 		modelLoaderBase = VehicleModel.getModelLoaderBase(modelResource, textureResource, resourceProvider, flipTextureV);
 		modelSupplier = modelLoaderBase::get;
@@ -52,6 +52,10 @@ public final class RailResource extends RailResourceSchema implements StoredMode
 
 	public int getColor() {
 		return CustomResourceTools.colorStringToInt(color);
+	}
+
+	public int getSoundIndex() {
+		return (int)soundIndex;
 	}
 
 	public double getRepeatInterval() {

--- a/src/main/java/org/mtr/servlet/ResourcePackCreatorOperationServlet.java
+++ b/src/main/java/org/mtr/servlet/ResourcePackCreatorOperationServlet.java
@@ -101,7 +101,7 @@ public final class ResourcePackCreatorOperationServlet extends AbstractResourceP
 				} else if (targetSpeed < speed) {
 					speed = Math.max(targetSpeed, speed - speedChange);
 				}
-				vehicleSoundBase.playMotorSound(clientPlayerEntity.blockPosition(), speed, speed - oldSpeed, acceleration, true);
+				vehicleSoundBase.playVehicleSound(new VehicleSoundBase.VehicleSoundParameters(new VehicleSoundBase.RunSoundInfo(0, 0, 1), clientPlayerEntity.blockPosition(), speed, speed - oldSpeed, acceleration, true));
 			}
 		}
 	}

--- a/src/main/java/org/mtr/sound/BveConfigFile.java
+++ b/src/main/java/org/mtr/sound/BveConfigFile.java
@@ -1,5 +1,6 @@
 package org.mtr.sound;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import org.apache.commons.lang3.StringUtils;
@@ -9,10 +10,10 @@ import java.util.Locale;
 
 public class BveConfigFile {
 
-	public final @Nullable SoundEvent[] run = new SoundEvent[1];
-	public final @Nullable SoundEvent[] flange = new SoundEvent[1];
-	public final @Nullable SoundEvent[] motor = new SoundEvent[40];
-	public final @Nullable SoundEvent[] joint = new SoundEvent[1];
+	public final Int2ObjectOpenHashMap<SoundEvent> run = new Int2ObjectOpenHashMap<>();
+	public final Int2ObjectOpenHashMap<SoundEvent> flange = new Int2ObjectOpenHashMap<>();
+	public final Int2ObjectOpenHashMap<SoundEvent> motor = new Int2ObjectOpenHashMap<>();
+	public final Int2ObjectOpenHashMap<SoundEvent> joint = new Int2ObjectOpenHashMap<>();
 
 	@Nullable
 	public final SoundEvent air;
@@ -128,29 +129,17 @@ public class BveConfigFile {
 						break;
 					case "run":
 					case "rolling":
-						if (Integer.parseInt(key) >= run.length) {
-							break;
-						}
-						run[Integer.parseInt(key)] = valueAsSoundEvent;
+						run.put(Integer.parseInt(key), valueAsSoundEvent);
 						break;
 					case "flange":
-						if (Integer.parseInt(key) >= flange.length) {
-							break;
-						}
-						flange[Integer.parseInt(key)] = valueAsSoundEvent;
+						flange.put(Integer.parseInt(key), valueAsSoundEvent);
 						break;
 					case "motor":
-						if (Integer.parseInt(key) >= motor.length) {
-							break;
-						}
-						motor[Integer.parseInt(key)] = valueAsSoundEvent;
+						motor.put(Integer.parseInt(key), valueAsSoundEvent);
 						break;
 					case "joint":
 					case "switch":
-						if (Integer.parseInt(key) >= joint.length) {
-							break;
-						}
-						joint[Integer.parseInt(key)] = valueAsSoundEvent;
+						joint.put(Integer.parseInt(key), valueAsSoundEvent);
 						break;
 					case "brake":
 						switch (key) {

--- a/src/main/java/org/mtr/sound/BveVehicleSound.java
+++ b/src/main/java/org/mtr/sound/BveVehicleSound.java
@@ -1,6 +1,6 @@
 package org.mtr.sound;
 
-import net.minecraft.client.Minecraft;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvent;
 import org.jspecify.annotations.Nullable;
@@ -22,6 +22,8 @@ public class BveVehicleSound extends VehicleSoundBase {
 	private boolean isCompressorActive;
 	private boolean isCompressorActiveLastElapsed;
 
+	private int defaultRunSoundIndex = -1;
+
 	private final VehicleLoopingSoundHolder vehicleLoopingSoundHolder;
 
 	public BveVehicleSound(BveVehicleSoundConfig config) {
@@ -31,17 +33,21 @@ public class BveVehicleSound extends VehicleSoundBase {
 		isCompressorActive = randomInt(0, 20) == 0; // Currently set to 1/20 at client-side load
 		isCompressorActiveLastElapsed = isCompressorActive;
 
-		final VehicleLoopingSoundInstance[] soundLoopMotor = new VehicleLoopingSoundInstance[config.config.motor.length];
-		for (int i = 0; i < Math.min(config.config.motor.length, config.motorData.getSoundCount()); i++) {
-			final SoundEvent motorSoundEvent = config.config.motor[i];
-			if (motorSoundEvent != null) {
-				soundLoopMotor[i] = new VehicleLoopingSoundInstance(motorSoundEvent);
-			}
-		}
+		final Int2ObjectOpenHashMap<VehicleLoopingSoundInstance> soundLoopMotor = new Int2ObjectOpenHashMap<>();
+		final Int2ObjectOpenHashMap<VehicleLoopingSoundInstance> soundLoopRun = new Int2ObjectOpenHashMap<>();
+
+		config.config.motor.forEach((index, soundEvent) -> {
+			soundLoopMotor.put((int)index, new VehicleLoopingSoundInstance(soundEvent));
+		});
+		config.config.run.forEach((index, soundEvent) -> {
+			if(defaultRunSoundIndex == -1) defaultRunSoundIndex = index;
+			soundLoopRun.put((int)index, new VehicleLoopingSoundInstance(soundEvent));
+		});
+
 		vehicleLoopingSoundHolder = new VehicleLoopingSoundHolder(
 			soundLoopMotor,
-			config.config.run[0] == null ? null : new VehicleLoopingSoundInstance(config.config.run[0]),
-			config.config.flange[0] == null ? null : new VehicleLoopingSoundInstance(config.config.flange[0]),
+			soundLoopRun,
+			config.config.flange.isEmpty() ? null : new VehicleLoopingSoundInstance(config.config.flange.get(0)),
 			config.config.noise == null ? null : new VehicleLoopingSoundInstance(config.config.noise),
 			config.config.shoe == null ? null : new VehicleLoopingSoundInstance(config.config.shoe),
 			config.config.compressorLoop == null ? null : new VehicleLoopingSoundInstance(config.config.compressorLoop)
@@ -49,18 +55,41 @@ public class BveVehicleSound extends VehicleSoundBase {
 	}
 
 	@Override
-	public void playMotorSound(BlockPos blockPos, float speed, float speedChange, float acceleration, boolean isOnRoute) {
+	public void playVehicleSound(VehicleSoundParameters input) {
 		final float secondsElapsed = MTRClient.getGameTimeDeltaTicks() / 20;
-		final float speedKilometersPerHour = speed * 3600;
-		final float speedMetersPerSecond = speed * 1000;
+		final float speedKilometersPerHour = input.speed() * 3600;
+		final float speedMetersPerSecond = input.speed() * 1000;
 
-		// Rolling noise
-		if (vehicleLoopingSoundHolder.soundLoopRun != null) {
-			vehicleLoopingSoundHolder.soundLoopRun.setData(Math.min(1, speedMetersPerSecond * 0.04F), speedMetersPerSecond * 0.04F, blockPos);
+		// Run noise
+		final float runSoundBlendRatio = input.runSound().blendLevel();
+		final float volume = Math.min(1, speedMetersPerSecond * 0.04F);
+		final float pitch = speedMetersPerSecond * 0.04F;
+		final int runIndexOld;
+		final int runIndexNew;
+
+		if(vehicleLoopingSoundHolder.soundLoopRun().containsKey(input.runSound().index())) {
+			runIndexOld = input.runSound().index();
+		} else {
+			// Falls back to default sound index
+			runIndexOld = defaultRunSoundIndex;
+		}
+		if(vehicleLoopingSoundHolder.soundLoopRun().containsKey(input.runSound().nextIndex())) {
+			runIndexNew = input.runSound().nextIndex();
+		} else {
+			runIndexNew = defaultRunSoundIndex;
 		}
 
+		vehicleLoopingSoundHolder.soundLoopRun.forEach((runIndex, runSound) -> {
+			if(runIndex == runIndexOld || runIndex == runIndexNew) {
+				float indexVolumeFactor = runIndexOld == runIndexNew ? 1 : (runIndex == runIndexOld ? 1 - runSoundBlendRatio : runSoundBlendRatio);
+				runSound.setData(volume * indexVolumeFactor, pitch, input.blockPos());
+			} else {
+				runSound.setData(0, pitch, input.blockPos());
+			}
+		});
+
 		// Simulation of circuit breaker in traction controller
-		float motorTarget = Math.signum(speedChange);
+		float motorTarget = Math.signum(input.speedChange());
 		if (motorTarget == 0 && speedMetersPerSecond != 0) {
 			motorTarget = config.config.motorOutputAtCoast;
 		}
@@ -102,32 +131,29 @@ public class BveVehicleSound extends VehicleSoundBase {
 		}
 		if (vehicleLoopingSoundHolder.soundLoopCompressor != null) {
 			// NOTE: Attack sound playback is not to BVE specification.
-			vehicleLoopingSoundHolder.soundLoopCompressor.setData(isCompressorActive ? 1 : 0, 1, blockPos);
+			vehicleLoopingSoundHolder.soundLoopCompressor.setData(isCompressorActive ? 1 : 0, 1, input.blockPos());
 		}
 		if (isCompressorActive && !isCompressorActiveLastElapsed) {
-			playSoundInWorld(config.config.compressorAttack, blockPos);
+			playSoundInWorld(config.config.compressorAttack, input.blockPos());
 		} else if (!isCompressorActive && isCompressorActiveLastElapsed) {
-			playSoundInWorld(config.config.compressorRelease, blockPos);
+			playSoundInWorld(config.config.compressorRelease, input.blockPos());
 		}
 
 		// Motor noise
-		for (int i = 0; i < config.motorData.getSoundCount(); i++) {
-			final VehicleLoopingSoundInstance vehicleLoopingSoundInstance = vehicleLoopingSoundHolder.soundLoopMotor[i];
-			if (vehicleLoopingSoundInstance != null) {
-				vehicleLoopingSoundInstance.setData(config.motorData.getVolume(i, speedKilometersPerHour, motorCurrentOutput) * config.config.motorVolumeMultiply, config.motorData.getPitch(i, speedKilometersPerHour, motorCurrentOutput), blockPos);
-			}
-		}
+		vehicleLoopingSoundHolder.soundLoopMotor.forEach((motorIndex, vehicleLoopingSoundInstance) -> {
+			vehicleLoopingSoundInstance.setData(config.motorData.getVolume(motorIndex, speedKilometersPerHour, motorCurrentOutput) * config.config.motorVolumeMultiply, config.motorData.getPitch(motorIndex, speedKilometersPerHour, motorCurrentOutput), input.blockPos());
+		});
 
 		// TODO play flange sounds
 		// Flange noise
 		if (vehicleLoopingSoundHolder.soundLoopFlange != null) {
-			vehicleLoopingSoundHolder.soundLoopFlange.setData(0, 1, blockPos);
+			vehicleLoopingSoundHolder.soundLoopFlange.setData(0, 1, input.blockPos());
 		}
 
 		// Brake shoe rubbing noise (below regeneration brake cutoff limit)
 		if (vehicleLoopingSoundHolder.soundLoopShoe != null) {
 			final float shoePitch = 1 / (speedMetersPerSecond + 1) + 1;
-			float shoeGain = speedMetersPerSecond < config.config.regenerationLimit && speedChange < 0 ? 1 : 0;
+			float shoeGain = speedMetersPerSecond < config.config.regenerationLimit && input.speedChange() < 0 ? 1 : 0;
 			if (speedMetersPerSecond < 1.39) {
 				final float t = speedMetersPerSecond * speedMetersPerSecond;
 				shoeGain *= 1.5552F * t - 0.746496F * speedMetersPerSecond * t;
@@ -135,34 +161,34 @@ public class BveVehicleSound extends VehicleSoundBase {
 				final float t = speedMetersPerSecond - 12.5F;
 				shoeGain *= 1 / (0.1F * t * t + 1);
 			}
-			vehicleLoopingSoundHolder.soundLoopShoe.setData(shoeGain, shoePitch, blockPos);
+			vehicleLoopingSoundHolder.soundLoopShoe.setData(shoeGain, shoePitch, input.blockPos());
 		}
 
 		// Constant loop noise
 		if (vehicleLoopingSoundHolder.soundLoopNoise != null) {
-			vehicleLoopingSoundHolder.soundLoopNoise.setData(isOnRoute ? 1 : 0, 1, blockPos);
+			vehicleLoopingSoundHolder.soundLoopNoise.setData(input.isOnRoute() ? 1 : 0, 1, input.blockPos());
 		}
 
 		// Air brake application and release noise
-		if (oldSpeedChange < 0 && speedChange >= 0) {
-			playSoundInWorld(config.config.brakeHandleRelease, blockPos);
+		if (oldSpeedChange < 0 && input.speedChange() >= 0) {
+			playSoundInWorld(config.config.brakeHandleRelease, input.blockPos());
 			if (speedMetersPerSecond < config.config.regenerationLimit) {
-				playSoundInWorld(config.config.airZero, blockPos);
+				playSoundInWorld(config.config.airZero, input.blockPos());
 			}
-		} else if (oldSpeedChange <= 0 && speedChange > 0 && speedMetersPerSecond < 0.3) {
-			playSoundInWorld(config.config.airHigh, blockPos);
-		} else if (oldSpeedChange >= 0 && speedChange < 0) {
+		} else if (oldSpeedChange <= 0 && input.speedChange() > 0 && speedMetersPerSecond < 0.3) {
+			playSoundInWorld(config.config.airHigh, input.blockPos());
+		} else if (oldSpeedChange >= 0 && input.speedChange() < 0) {
 			mrPress -= (int) config.config.mrServiceBrakeReduce;
-			playSoundInWorld(config.config.brakeHandleApply, blockPos);
+			playSoundInWorld(config.config.brakeHandleApply, input.blockPos());
 		}
 
 		// Emergency brake application after returning to depot
-		if (oldOnRoute && !isOnRoute) {
-			playSoundInWorld(config.config.brakeEmergency, blockPos);
+		if (oldOnRoute && !input.isOnRoute()) {
+			playSoundInWorld(config.config.brakeEmergency, input.blockPos());
 		}
 
-		oldSpeedChange = speedChange;
-		oldOnRoute = isOnRoute;
+		oldSpeedChange = input.speedChange();
+		oldOnRoute = input.isOnRoute();
 		isCompressorActiveLastElapsed = isCompressorActive;
 	}
 
@@ -189,16 +215,18 @@ public class BveVehicleSound extends VehicleSoundBase {
 		return new Random().nextInt(maxExclusive - minInclusive) + minInclusive;
 	}
 
-	private record VehicleLoopingSoundHolder(@Nullable VehicleLoopingSoundInstance[] soundLoopMotor, @Nullable VehicleLoopingSoundInstance soundLoopRun, @Nullable VehicleLoopingSoundInstance soundLoopFlange, @Nullable VehicleLoopingSoundInstance soundLoopNoise, @Nullable VehicleLoopingSoundInstance soundLoopShoe, @Nullable VehicleLoopingSoundInstance soundLoopCompressor) {
+	private record VehicleLoopingSoundHolder(Int2ObjectOpenHashMap<VehicleLoopingSoundInstance> soundLoopMotor, Int2ObjectOpenHashMap<VehicleLoopingSoundInstance> soundLoopRun, @Nullable VehicleLoopingSoundInstance soundLoopFlange, @Nullable VehicleLoopingSoundInstance soundLoopNoise, @Nullable VehicleLoopingSoundInstance soundLoopShoe, @Nullable VehicleLoopingSoundInstance soundLoopCompressor) {
 
 		public void dispose() {
-			for (VehicleLoopingSoundInstance instance : soundLoopMotor) {
+			for (VehicleLoopingSoundInstance instance : soundLoopMotor.values()) {
 				if (instance != null) {
 					instance.dispose();
 				}
 			}
-			if (soundLoopRun != null) {
-				soundLoopRun.dispose();
+			for (VehicleLoopingSoundInstance instance : soundLoopRun.values()) {
+				if (instance != null) {
+					instance.dispose();
+				}
 			}
 			if (soundLoopFlange != null) {
 				soundLoopFlange.dispose();

--- a/src/main/java/org/mtr/sound/LegacyVehicleSound.java
+++ b/src/main/java/org/mtr/sound/LegacyVehicleSound.java
@@ -38,21 +38,21 @@ public class LegacyVehicleSound extends VehicleSoundBase {
 	}
 
 	@Override
-	public void playMotorSound(BlockPos blockPos, float speed, float speedChange, float acceleration, boolean isOnRoute) {
+	public void playVehicleSound(VehicleSoundParameters vehicle) {
 		if (!MTRClient.canPlaySound()) {
 			return;
 		}
 
 		if (legacySpeedSoundCount > 0 && legacySpeedSoundBaseResource != null) {
-			final double referenceAcceleration = legacyConstantPlaybackSpeed ? acceleration : Siding.ACCELERATION_DEFAULT;
-			final int floorSpeed = (int) Math.floor(speed / referenceAcceleration / MTRClient.MILLIS_PER_SPEED_SOUND);
+			final double referenceAcceleration = legacyConstantPlaybackSpeed ? vehicle.acceleration() : Siding.ACCELERATION_DEFAULT;
+			final int floorSpeed = (int) Math.floor(vehicle.speed() / referenceAcceleration / MTRClient.MILLIS_PER_SPEED_SOUND);
 			if (floorSpeed > 0) {
 				final Random random = new Random();
 
 				final int index = Math.min(floorSpeed, legacySpeedSoundCount) - 1;
-				final boolean isAccelerating = speedChange == 0 ? legacyUseAccelerationSoundsWhenCoasting || random.nextBoolean() : speedChange > 0;
+				final boolean isAccelerating = vehicle.speedChange() == 0 ? legacyUseAccelerationSoundsWhenCoasting || random.nextBoolean() : vehicle.speedChange() > 0;
 				final String speedSoundId = legacySpeedSoundBaseResource + (isAccelerating ? SOUND_ACCELERATION : SOUND_DECELERATION) + index / SOUND_GROUP_SIZE + SOUND_GROUP_LETTERS[index % SOUND_GROUP_SIZE];
-				ScheduledSound.schedule(blockPos, SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MTR.MOD_ID, speedSoundId)), 1, 1);
+				ScheduledSound.schedule(vehicle.blockPos(), SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MTR.MOD_ID, speedSoundId)), 1, 1);
 			}
 		}
 	}

--- a/src/main/java/org/mtr/sound/VehicleSoundBase.java
+++ b/src/main/java/org/mtr/sound/VehicleSoundBase.java
@@ -1,10 +1,13 @@
 package org.mtr.sound;
 
 import net.minecraft.core.BlockPos;
+import org.mtr.client.CustomResourceLoader;
+import org.mtr.core.data.Rail;
+import org.mtr.resource.RailResource;
 
 public abstract class VehicleSoundBase {
 
-	public abstract void playMotorSound(BlockPos blockPos, float speed, float speedChange, float acceleration, boolean isOnRoute);
+	public abstract void playVehicleSound(VehicleSoundParameters vehicleSoundParameters);
 
 	public final void playDoorSound(BlockPos blockPos, double doorValue, double oldDoorValue) {
 		if (doorValue > 0 && oldDoorValue == 0) {
@@ -20,4 +23,22 @@ public abstract class VehicleSoundBase {
 	protected abstract void playDoorSound(BlockPos blockPos, boolean isOpen);
 
 	protected abstract double getDoorCloseSoundTime();
+
+	public record VehicleSoundParameters(RunSoundInfo runSound, BlockPos blockPos, float speed, float speedChange, float acceleration, boolean isOnRoute) {};
+
+	public record RunSoundInfo(int index, int nextIndex, float blendLevel) {
+		public static RunSoundInfo create(Rail railTail, Rail railHead, float pathDelta) {
+			int lastRunSound = 0;
+			if(!railTail.getStyles().isEmpty()) {
+				RailResource railResource = CustomResourceLoader.getRailById(railTail.getStyles().getFirst());
+				if(railResource != null) lastRunSound = railResource.getSoundIndex();
+			}
+			int nextRunSound = lastRunSound;
+			if(!railHead.equals(railTail) && !railHead.getStyles().isEmpty()) {
+				RailResource railResource = CustomResourceLoader.getRailById(railHead.getStyles().getFirst());
+				if(railResource != null) nextRunSound = railResource.getSoundIndex();
+			}
+			return new RunSoundInfo(lastRunSound, nextRunSound, pathDelta);
+		}
+	}
 }


### PR DESCRIPTION
Since the integration of BVE Train Sounds into the mod, only 1 run sound is used in-game.

This PR:
- (Additional refactor) Change `RenderVehicleHelper.canOpenDoors()` to only check the door, and `checkAndOpenNearbyDoors` to open the door as well.
- Converts the sound array into a map (This is also how it's internally represented in OpenBVE, since sound index are arbitrary numbers)
- Add `soundIndex` to RailResource, allowing custom rail model to specify a custom sound index
- Allow vehicles to play different run index depending on the (top) rail model. (Falls back to the first-parsed run sound if sound index does not exist in vehicle)
- This does nothing for legacy vehicle sounds

#### Sound Blending
The sound blending between 2 rail with different sound index is calculated by the ratio of the vehicle car occupying the 2 rails.
(e.g. If the car is 25% at Rail B, and 75% at Rail A, then B's index would be played at 25% of it's original volume, and 75% for Rail A's index)

#### Index scheme
In BVE there's no standard on what sound index to use in what situation, which leads to different community using different rail index for different situations. (Underground/Bridge Crossing/Overground...)

Thus we should probably define some sort of standard on what index to use in what situations in the future, so rails and vehicles can be easily mixed-and-matched with each other. (Say, 0 for generic, 50 for underground, 51 for overground, so on and so fourth..., and then have arbitrary sounds defined starting at 200 or smth)

But that can be thought later