### PR TITLE
Add multi node support for bridge and tunnel creators

### DIFF
--- a/src/main/java/org/mtr/MTR.java
+++ b/src/main/java/org/mtr/MTR.java
@@ -109,6 +109,7 @@ public final class MTR {
 		// Register packets
 		RegistryServer.setupPackets();
 		RegistryServer.registerPacket(PacketAddBalance.class, PacketAddBalance::new);
+		RegistryServer.registerPacket(PacketApplyRailAction.class, PacketApplyRailAction::new);
 		RegistryServer.registerPacket(PacketBlockRails.class, PacketBlockRails::new);
 		RegistryServer.registerPacket(PacketBroadcastRailActions.class, PacketBroadcastRailActions::new);
 		RegistryServer.registerPacket(PacketCheckRouteIdHasDisabledAnnouncements.class, PacketCheckRouteIdHasDisabledAnnouncements::new);

--- a/src/main/java/org/mtr/item/ItemBridgeCreator.java
+++ b/src/main/java/org/mtr/item/ItemBridgeCreator.java
@@ -14,7 +14,7 @@ public class ItemBridgeCreator extends ItemNodeModifierSelectableBlockBase {
 	}
 
 	@Override
-	protected void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
+	public void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
 		final BlockState blockState = getSavedState(itemStack);
 		MTR.getRailActionModule(serverPlayerEntity.serverLevel(), railActionModule -> railActionModule.markRailForBridge(rail, serverPlayerEntity, radius, blockState));
 	}

--- a/src/main/java/org/mtr/item/ItemNodeModifierSelectableBlockBase.java
+++ b/src/main/java/org/mtr/item/ItemNodeModifierSelectableBlockBase.java
@@ -15,13 +15,21 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jspecify.annotations.Nullable;
+import org.mtr.MTR;
 import org.mtr.MTRClient;
 import org.mtr.block.BlockNode;
+import org.mtr.client.MinecraftClientData;
+import org.mtr.core.data.Position;
 import org.mtr.core.data.Rail;
 import org.mtr.core.data.TransportMode;
 import org.mtr.core.tool.Angle;
 import org.mtr.generated.lang.TranslationProvider;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
+import org.mtr.packet.PacketApplyRailAction;
 import org.mtr.registry.DataComponentTypes;
+import org.mtr.registry.RegistryClient;
 
 import java.util.List;
 
@@ -42,6 +50,14 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 		radius = width / 2;
 	}
 
+	public int getRadius() {
+		return radius;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+
 	@Override
 	public InteractionResult useOn(UseOnContext context) {
 		if (canSaveBlock) {
@@ -59,6 +75,17 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 					playerEntity.displayClientMessage(TranslationProvider.TOOLTIP_MTR_SELECTED_MATERIAL.getText(Component.translatable(neighborState.getBlock().getDescriptionId()).getString()), true);
 					context.getItemInHand().set(DataComponentTypes.BLOCK_ID.get(), Block.getId(neighborState));
 					return InteractionResult.SUCCESS;
+				}
+			}
+		}
+
+		final Player player = context.getPlayer();
+		if (context.getLevel().isClientSide() && player != null && !player.isShiftKeyDown()) {
+			final BlockPos startPos = context.getItemInHand().get(DataComponentTypes.START_POS.get());
+			if (startPos != null && clickCondition(context)) {
+				final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> path = findRailPath(startPos, context.getClickedPos());
+				if (path != null && path.size() > 1) {
+					RegistryClient.sendPacketToServer(new PacketApplyRailAction(path));
 				}
 			}
 		}
@@ -101,5 +128,57 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 		return blockId == null ? Blocks.AIR.defaultBlockState() : Block.stateById(blockId);
 	}
 
-	protected abstract void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height);
+	public abstract void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height);
+
+	/**
+	 * BFS through the client-side rail graph to find the shortest path of rail segments
+	 * connecting startBlockPos to endBlockPos. Returns null if no path exists or if the
+	 * client's rail graph ({@code positionsToRail}) is not yet populated for these nodes.
+	 * Returns a list ordered from start to end, each entry being the two node endpoints
+	 * of one rail segment.
+	 */
+	@Nullable
+	private static ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> findRailPath(BlockPos startBlockPos, BlockPos endBlockPos) {
+		final Position startPosition = MTR.blockPosToPosition(startBlockPos);
+		final Position endPosition = MTR.blockPosToPosition(endBlockPos);
+
+		if (!MinecraftClientData.getInstance().positionsToRail.containsKey(startPosition)) {
+			return null;
+		}
+
+		final Object2ObjectOpenHashMap<Position, Position> parentMap = new Object2ObjectOpenHashMap<>();
+		final ObjectArrayList<Position> queue = new ObjectArrayList<>();
+		queue.add(startPosition);
+		parentMap.put(startPosition, startPosition);
+
+		boolean found = false;
+		int queueIndex = 0;
+		while (queueIndex < queue.size()) {
+			final Position current = queue.get(queueIndex++);
+			if (current.equals(endPosition)) {
+				found = true;
+				break;
+			}
+			MinecraftClientData.getInstance().positionsToRail.getOrDefault(current, new Object2ObjectOpenHashMap<>()).keySet().forEach(neighbor -> {
+				if (!parentMap.containsKey(neighbor)) {
+					parentMap.put(neighbor, current);
+					queue.add(neighbor);
+				}
+			});
+		}
+
+		if (!found) {
+			return null;
+		}
+
+		// Reconstruct path as ordered (start, end) pairs, one per rail segment
+		final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> path = new ObjectArrayList<>();
+		Position current = endPosition;
+		while (!parentMap.get(current).equals(current)) {
+			final Position previous = parentMap.get(current);
+			path.add(0, new ObjectObjectImmutablePair<>(MTR.positionToBlockPos(previous), MTR.positionToBlockPos(current)));
+			current = previous;
+		}
+		return path;
+	}
 }

--- a/src/main/java/org/mtr/item/ItemNodeModifierSelectableBlockBase.java
+++ b/src/main/java/org/mtr/item/ItemNodeModifierSelectableBlockBase.java
@@ -130,13 +130,6 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 
 	public abstract void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height);
 
-	/**
-	 * BFS through the client-side rail graph to find the shortest path of rail segments
-	 * connecting startBlockPos to endBlockPos. Returns null if no path exists or if the
-	 * client's rail graph ({@code positionsToRail}) is not yet populated for these nodes.
-	 * Returns a list ordered from start to end, each entry being the two node endpoints
-	 * of one rail segment.
-	 */
 	@Nullable
 	private static ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> findRailPath(BlockPos startBlockPos, BlockPos endBlockPos) {
 		final Position startPosition = MTR.blockPosToPosition(startBlockPos);
@@ -171,7 +164,6 @@ public abstract class ItemNodeModifierSelectableBlockBase extends ItemNodeModifi
 			return null;
 		}
 
-		// Reconstruct path as ordered (start, end) pairs, one per rail segment
 		final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> path = new ObjectArrayList<>();
 		Position current = endPosition;
 		while (!parentMap.get(current).equals(current)) {

--- a/src/main/java/org/mtr/item/ItemTunnelCreator.java
+++ b/src/main/java/org/mtr/item/ItemTunnelCreator.java
@@ -13,7 +13,7 @@ public class ItemTunnelCreator extends ItemNodeModifierSelectableBlockBase {
 	}
 
 	@Override
-	protected void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
+	public void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
 		MTR.getRailActionModule(serverPlayerEntity.serverLevel(), railActionModule -> railActionModule.markRailForTunnel(rail, serverPlayerEntity, radius, height));
 	}
 }

--- a/src/main/java/org/mtr/item/ItemTunnelWallCreator.java
+++ b/src/main/java/org/mtr/item/ItemTunnelWallCreator.java
@@ -14,7 +14,7 @@ public class ItemTunnelWallCreator extends ItemNodeModifierSelectableBlockBase {
 	}
 
 	@Override
-	protected void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
+	public void onConnect(Rail rail, ServerPlayer serverPlayerEntity, ItemStack itemStack, int radius, int height) {
 		final BlockState blockState = getSavedState(itemStack);
 		MTR.getRailActionModule(serverPlayerEntity.serverLevel(), railActionModule -> railActionModule.markRailForTunnelWall(rail, serverPlayerEntity, radius, height, blockState));
 	}

--- a/src/main/java/org/mtr/packet/PacketApplyRailAction.java
+++ b/src/main/java/org/mtr/packet/PacketApplyRailAction.java
@@ -9,7 +9,6 @@ import org.mtr.item.ItemNodeModifierSelectableBlockBase;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 
-
 public final class PacketApplyRailAction extends PacketHandler {
 
 	private final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> railPairs;

--- a/src/main/java/org/mtr/packet/PacketApplyRailAction.java
+++ b/src/main/java/org/mtr/packet/PacketApplyRailAction.java
@@ -1,0 +1,58 @@
+package org.mtr.packet;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import org.mtr.item.ItemNodeModifierBase;
+import org.mtr.item.ItemNodeModifierSelectableBlockBase;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
+
+
+public final class PacketApplyRailAction extends PacketHandler {
+
+	private final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> railPairs;
+
+	public PacketApplyRailAction(PacketBufferReceiver packetBufferReceiver) {
+		railPairs = new ObjectArrayList<>();
+		final int count = packetBufferReceiver.readInt();
+		for (int i = 0; i < count; i++) {
+			final BlockPos start = BlockPos.of(packetBufferReceiver.readLong());
+			final BlockPos end = BlockPos.of(packetBufferReceiver.readLong());
+			railPairs.add(new ObjectObjectImmutablePair<>(start, end));
+		}
+	}
+
+	public PacketApplyRailAction(ObjectArrayList<ObjectObjectImmutablePair<BlockPos, BlockPos>> railPairs) {
+		this.railPairs = railPairs;
+	}
+
+	@Override
+	public void write(PacketBufferSender packetBufferSender) {
+		packetBufferSender.writeInt(railPairs.size());
+		for (final ObjectObjectImmutablePair<BlockPos, BlockPos> pair : railPairs) {
+			packetBufferSender.writeLong(pair.left().asLong());
+			packetBufferSender.writeLong(pair.right().asLong());
+		}
+	}
+
+	@Override
+	public void runServer(MinecraftServer minecraftServer, ServerPlayer serverPlayerEntity) {
+		final ItemStack itemStack = serverPlayerEntity.getMainHandItem();
+		if (!(itemStack.getItem() instanceof ItemNodeModifierSelectableBlockBase item)) {
+			return;
+		}
+		final int capturedRadius = item.getRadius();
+		final int capturedHeight = item.getHeight();
+		for (final ObjectObjectImmutablePair<BlockPos, BlockPos> pair : railPairs) {
+			ItemNodeModifierBase.getRail(
+				serverPlayerEntity.serverLevel(),
+				pair.left(),
+				pair.right(),
+				serverPlayerEntity,
+				rail -> item.onConnect(rail, serverPlayerEntity, itemStack, capturedRadius, capturedHeight)
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When using the Bridge, Tunnel, or Tunnel Wall Creators between two nodes that are not directly adjacent (with one or more intermediate nodes between them), the action always fails with a "Rail not found" error, even when a valid connected path exists.

<img width="1074" height="127" alt="image" src="https://github.com/user-attachments/assets/c58694b3-891a-4cdb-ad47-e2911a3d01c3" />

This is because the existing server-side handler looks up exactly one rail by its two endpoint positions and has no concept of a multi-segment path.

## Solution

First click selects a start node as before. The second click can now target any node reachable through the rail network — not just a directly adjacent one. The action is applied to every rail segment along the shortest path between the two selected nodes.

## Implementation

- Client-side BFS — on the second click, a breadth-first search runs against MinecraftClientData.positionsToRail (the rail graph the client already holds) to find the shortest sequence of rail segments connecting start to end.
- PacketApplyRailAction (new C2S packet) — carries an ordered list of (BlockPos start, BlockPos end) pairs, one per segment. Only sent when the path has more than one segment; single-segment clicks continue through the existing server-side path unchanged.
- Server handler — calls ItemNodeModifierBase.getRail() for each pair in sequence, which enqueues a RailAction per segment into RailActionModule. Since the module already processes actions one at a time from a queue, all segments build in order with no additional changes needed there.

## Notes

- If positionsToRail is not yet populated (player joined but hasn't loaded rail data), the BFS returns no path and only single-segment connections work. Opening the Dashboard populates the graph.
- Single-node-pair (direct) connections are completely unaffected by this change.