### PR TITLE
Fix frame stalls around very long curved rails

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/client/MinecraftClientData.java
+++ b/fabric/src/main/java/org/mtr/mod/client/MinecraftClientData.java
@@ -71,7 +71,7 @@ public final class MinecraftClientData extends ClientData {
 			if (railWrapper == null) {
 				railWrapperList.put(hexId, new RailWrapper(rail, hexId));
 			} else {
-				railWrapper.rail = rail;
+				railWrapper.setRail(rail);
 			}
 		}));
 
@@ -231,8 +231,8 @@ public final class MinecraftClientData extends ClientData {
 
 		public boolean shouldRender;
 		public final String hexId;
-		public final Vec3d startVector;
-		public final Vec3d endVector;
+		public Vec3d startVector;
+		public Vec3d endVector;
 		private Rail rail;
 
 		private RailWrapper(Rail rail, String hexId) {
@@ -240,6 +240,16 @@ public final class MinecraftClientData extends ClientData {
 			this.hexId = hexId;
 			startVector = new Vec3d(rail.railMath.minX, rail.railMath.minY, rail.railMath.minZ);
 			endVector = new Vec3d(rail.railMath.maxX, rail.railMath.maxY, rail.railMath.maxZ);
+		}
+
+		private void setRail(Rail rail) {
+			this.rail = rail;
+			final RailMath railMath = rail.railMath;
+			if (startVector.getX() != railMath.minX || startVector.getY() != railMath.minY || startVector.getZ() != railMath.minZ ||
+					endVector.getX() != railMath.maxX || endVector.getY() != railMath.maxY || endVector.getZ() != railMath.maxZ) {
+				startVector = new Vec3d(railMath.minX, railMath.minY, railMath.minZ);
+				endVector = new Vec3d(railMath.maxX, railMath.maxY, railMath.maxZ);
+			}
 		}
 
 		public Rail getRail() {

--- a/fabric/src/main/java/org/mtr/mod/render/RailCullingHelper.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RailCullingHelper.java
@@ -1,0 +1,64 @@
+package org.mtr.mod.render;
+
+import com.logisticscraft.occlusionculling.OcclusionCullingInstance;
+import com.logisticscraft.occlusionculling.util.Vec3d;
+import org.mtr.mapping.mapper.MinecraftClientHelper;
+import org.mtr.mod.client.MinecraftClientData;
+
+final class RailCullingHelper {
+
+	private static final double AABB_EXPANSION = 0.5;
+	// OcclusionCulling walks every cell in the expanded AABB at least once. Keep a single rail from monopolizing the shared worker thread.
+	private static final long MAX_OCCLUSION_CELL_COUNT = 1L << 20;
+
+	private RailCullingHelper() {
+	}
+
+	static boolean isVisible(MinecraftClientData.RailWrapper railWrapper, Vec3d camera, OcclusionCullingInstance occlusionCullingInstance) {
+		final Vec3d startVector = railWrapper.startVector;
+		final Vec3d endVector = railWrapper.endVector;
+		if (canUseOcclusionCulling(startVector.getX(), startVector.getY(), startVector.getZ(), endVector.getX(), endVector.getY(), endVector.getZ())) {
+			return occlusionCullingInstance.isAABBVisible(startVector, endVector, camera);
+		}
+		return isWithinHorizontalRenderDistance(camera.getX(), camera.getZ(), startVector.getX(), startVector.getZ(), endVector.getX(), endVector.getZ(), MinecraftClientHelper.getRenderDistance() * 16D);
+	}
+
+	static boolean canUseOcclusionCulling(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final long spanX = getExpandedBlockSpan(minX, maxX);
+		final long spanY = getExpandedBlockSpan(minY, maxY);
+		final long spanZ = getExpandedBlockSpan(minZ, maxZ);
+		if (spanX > MAX_OCCLUSION_CELL_COUNT || spanY > MAX_OCCLUSION_CELL_COUNT / spanX) {
+			return false;
+		}
+		final long area = spanX * spanY;
+		return spanZ <= MAX_OCCLUSION_CELL_COUNT / area;
+	}
+
+	static boolean isWithinHorizontalRenderDistance(double cameraX, double cameraZ, double minX, double minZ, double maxX, double maxZ, double renderDistance) {
+		if (!Double.isFinite(cameraX) || !Double.isFinite(cameraZ) || !Double.isFinite(minX) || !Double.isFinite(minZ) || !Double.isFinite(maxX) || !Double.isFinite(maxZ) || !Double.isFinite(renderDistance)) {
+			return true;
+		}
+		if (renderDistance < 0) {
+			return false;
+		}
+
+		final double lowerX = Math.min(minX, maxX);
+		final double upperX = Math.max(minX, maxX);
+		final double lowerZ = Math.min(minZ, maxZ);
+		final double upperZ = Math.max(minZ, maxZ);
+		final double distanceX = Math.max(Math.max(lowerX - cameraX, 0), cameraX - upperX);
+		final double distanceZ = Math.max(Math.max(lowerZ - cameraZ, 0), cameraZ - upperZ);
+		return Math.hypot(distanceX, distanceZ) <= renderDistance;
+	}
+
+	private static long getExpandedBlockSpan(double first, double second) {
+		if (!Double.isFinite(first) || !Double.isFinite(second)) {
+			return MAX_OCCLUSION_CELL_COUNT + 1;
+		}
+
+		final double lower = Math.floor(Math.min(first, second) - AABB_EXPANSION);
+		final double upper = Math.floor(Math.max(first, second) + AABB_EXPANSION);
+		final double span = upper - lower + 1;
+		return span > 0 && span <= MAX_OCCLUSION_CELL_COUNT ? (long) span : MAX_OCCLUSION_CELL_COUNT + 1;
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
@@ -71,7 +71,7 @@ public class RenderRails implements IGui {
 		final ObjectArrayList<Rail> railsToRender = new ObjectArrayList<>();
 		MinecraftClientData.getInstance().railWrapperList.values().forEach(railWrapper -> {
 			cullingTasks.add(occlusionCullingInstance -> {
-				final boolean shouldRender = occlusionCullingInstance.isAABBVisible(railWrapper.startVector, railWrapper.endVector, camera);
+				final boolean shouldRender = RailCullingHelper.isVisible(railWrapper, camera, occlusionCullingInstance);
 				return () -> railWrapper.shouldRender = shouldRender;
 			});
 			if (railWrapper.shouldRender) {

--- a/fabric/src/test/java/org/mtr/mod/render/RailCullingHelperTest.java
+++ b/fabric/src/test/java/org/mtr/mod/render/RailCullingHelperTest.java
@@ -1,0 +1,37 @@
+package org.mtr.mod.render;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class RailCullingHelperTest {
+
+	@Test
+	public void chooseOcclusionCullingByExpandedCellCount() {
+		Assertions.assertTrue(RailCullingHelper.canUseOcclusionCulling(0, 0, 0, 722, 0, 722));
+		Assertions.assertFalse(RailCullingHelper.canUseOcclusionCulling(0, 0, 0, 723, 0, 723));
+		Assertions.assertFalse(RailCullingHelper.canUseOcclusionCulling(0, 0, 0, 100, 100, 100));
+	}
+
+	@Test
+	public void handleReversedAndInvalidBoundsWithoutOverflow() {
+		Assertions.assertTrue(RailCullingHelper.canUseOcclusionCulling(722, 0, 722, 0, 0, 0));
+		Assertions.assertFalse(RailCullingHelper.canUseOcclusionCulling(723, 0, 723, 0, 0, 0));
+		Assertions.assertFalse(RailCullingHelper.canUseOcclusionCulling(-Double.MAX_VALUE, 0, 0, Double.MAX_VALUE, 0, 0));
+		Assertions.assertFalse(RailCullingHelper.canUseOcclusionCulling(Double.NaN, 0, 0, 0, 0, 0));
+	}
+
+	@Test
+	public void measureHorizontalDistanceToClosestPointOnBox() {
+		Assertions.assertTrue(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, -1, -1, 1, 1, 0));
+		Assertions.assertTrue(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, 3, 4, 5, 6, 5));
+		Assertions.assertFalse(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, 3, 4, 5, 6, 4.999));
+		Assertions.assertTrue(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, 5, 6, 3, 4, 5));
+	}
+
+	@Test
+	public void failOpenForInvalidDistanceInputs() {
+		Assertions.assertTrue(RailCullingHelper.isWithinHorizontalRenderDistance(Double.NaN, 0, 0, 0, 0, 0, 0));
+		Assertions.assertTrue(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, 0, 0, Double.POSITIVE_INFINITY, 0, 0));
+		Assertions.assertFalse(RailCullingHelper.isWithinHorizontalRenderDistance(0, 0, 0, 0, 0, 0, -1));
+	}
+}


### PR DESCRIPTION
## 中文

### 问题

在跨越数千格的长弯轨附近快速转动或移动视角时，游戏会出现间歇性卡顿，FPS 会瞬间降到 0 附近。

### 修复内容

长弯轨的检测范围会非常大，原来的遮挡检测一次可能要检查数百万个方块。本 PR 保留普通轨道原来的检测方式，只对范围特别大的轨道改用简单的渲染距离判断。

### 效果

在同一存档中，原版可以复现卡顿，修复版未再出现，轨道材质显示正常。

对于特别长的轨道，新的判断可能会多渲染一小部分，但不会把渲染距离内的轨道隐藏掉。

### 测试

- 在 Minecraft 1.20.1 Fabric 下，使用同一存档进行了修复前后对比测试
- 18 个 Fabric 测试全部通过
- 这个分支支持的所有 Minecraft 版本都通过了 Fabric 和 Forge 编译

---

## English

### Problem

When the camera is moved or turned quickly near a curved rail spanning several thousand blocks, the game can stutter intermittently and FPS can briefly drop to nearly 0.

### Fix

Very long rails create a large area to check, and the existing occlusion check may scan millions of blocks at once. This PR keeps the existing check for normal rails and uses a simple render-distance check only for unusually large ones.

### Result

In the same world, the original build reproduced the stutter while the patched build did not, and rail textures rendered normally.

For very long rails, the new check may render a little more than before, but it will not hide rail sections within render distance.

### Tests

- On Minecraft 1.20.1 Fabric, the original and patched builds were compared in the same world
- All 18 Fabric tests passed
- Fabric and Forge compiled for every Minecraft version supported by this branch
