### PR TITLE
Reduce redundant rail rendering and broadcast serialization work

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/packet/PacketRequestResponseBase.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketRequestResponseBase.java
@@ -57,7 +57,13 @@ public abstract class PacketRequestResponseBase extends PacketHandler {
 					Init.REGISTRY.sendPacketToClient(serverPlayerEntity, getInstance(responseJson.toString()));
 				}
 			} else {
-				MinecraftServerHelper.iteratePlayers(serverWorld, serverPlayerEntityNew -> Init.REGISTRY.sendPacketToClient(serverPlayerEntityNew, getInstance(responseJson.toString())));
+				final String[] responseContent = {null};
+				MinecraftServerHelper.iteratePlayers(serverWorld, serverPlayerEntityNew -> {
+					if (responseContent[0] == null) {
+						responseContent[0] = responseJson.toString();
+					}
+					Init.REGISTRY.sendPacketToClient(serverPlayerEntityNew, getInstance(responseContent[0]));
+				});
 			}
 			runServerInbound(serverWorld, responseJson);
 		}, SerializedDataBase.class);

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
@@ -62,7 +62,7 @@ public class RenderRails implements IGui {
 			return;
 		}
 
-		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = new ObjectArrayList<>();
+		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = OptimizedRenderer.renderingShadows() ? null : new ObjectArrayList<>();
 		final Vector3d cameraPosition = minecraftClient.getGameRendererMapped().getCamera().getPos();
 		final Vec3d camera = new Vec3d(cameraPosition.getXMapped(), cameraPosition.getYMapped(), cameraPosition.getZMapped());
 		final boolean holdingRailRelated = isHoldingRailRelated(clientPlayerEntity);
@@ -70,10 +70,12 @@ public class RenderRails implements IGui {
 		// Finding visible rails
 		final ObjectArrayList<Rail> railsToRender = new ObjectArrayList<>();
 		MinecraftClientData.getInstance().railWrapperList.values().forEach(railWrapper -> {
-			cullingTasks.add(occlusionCullingInstance -> {
-				final boolean shouldRender = occlusionCullingInstance.isAABBVisible(railWrapper.startVector, railWrapper.endVector, camera);
-				return () -> railWrapper.shouldRender = shouldRender;
-			});
+			if (cullingTasks != null) {
+				cullingTasks.add(occlusionCullingInstance -> {
+					final boolean shouldRender = occlusionCullingInstance.isAABBVisible(railWrapper.startVector, railWrapper.endVector, camera);
+					return () -> railWrapper.shouldRender = shouldRender;
+				});
+			}
 			if (railWrapper.shouldRender) {
 				railsToRender.add(railWrapper.getRail());
 			}
@@ -203,7 +205,7 @@ public class RenderRails implements IGui {
 			}
 		}
 
-		if (!OptimizedRenderer.renderingShadows()) {
+		if (cullingTasks != null) {
 			MainRenderer.WORKER_THREAD.scheduleMTRRails(occlusionCullingInstance -> {
 				final ObjectArrayList<Runnable> tasks = new ObjectArrayList<>();
 				cullingTasks.forEach(occlusionCullingInstanceRunnableFunction -> tasks.add(occlusionCullingInstanceRunnableFunction.apply(occlusionCullingInstance)));


### PR DESCRIPTION
## Summary

- Avoid building rail occlusion-culling task lists during shader shadow passes, where culling results cannot be published.
- Preserve normal-pass culling and render shadows from the most recently published `RailWrapper.shouldRender` state.
- Serialize `ResponseType.ALL` response JSON at most once per broadcast while retaining distinct packet instances, recipient order, and send order.

## Motivation

Dense stations and nearby depots amplify per-frame work across synchronized rails. Broadcast responses also repeated identical JSON serialization for every connected player. These changes remove redundant allocation and CPU work without changing normal culling publication or packet fanout semantics.

## Verification

- Fabric 1.20.1 Gradle build passed.
- Covered compilation, Javadocs, source artifacts, model-validation tests, access-widener validation, shadowing, remapping, and packaging.
- No runtime FPS or TPS benchmark is claimed by this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)