### PR TITLE
perf(fabric): cache default rail meshes to reduce render-thread load

### DIFF
--- a/PERFORMANCE_HOTFIX.md
+++ b/PERFORMANCE_HOTFIX.md
@@ -1,0 +1,117 @@
+# Fabric 1.20.1 Rail Rendering Performance Hotfix
+
+This branch targets the client render-thread bottleneck caused by large numbers of MTR rails and station elements. The primary change caches eligible default rail geometry as static GPU meshes instead of tessellating and submitting the same rail vertices again on every frame.
+
+## Scope
+
+- Source base: upstream `4.0.6` branch at `240524a18d59edeb75cf8040cb209b91b428b5d7`.
+- Validated runtime: Fabric 1.20.1.
+- Exact tested artifact: `MTR-fabric-4.0.5+1.20.1-D3-GPU-mesh-hotfix.jar`.
+- The upstream source line is named `4.0.6`, while its current `gradle.properties` still sets the built MTR version to `4.0.5`.
+- The rail mesh cache is client-side and does not change the network protocol or world-save format. A matching server hotfix is not required for this rendering path.
+- The GPU mesh path requires MTR's `OptimizedRenderer`; when optimized rendering is unavailable, rails use the legacy renderer.
+- Forge and Minecraft versions other than Fabric 1.20.1 have not been validated for this release.
+
+## Controlled D3 Benchmark
+
+The benchmark used a local copy of the server's `world2` overworld and a fixed flight along the D3 track at Shuyuan North. Every accepted run was validated against the actual player coordinates; earlier captures where the player did not move were rejected.
+
+- Commanded route: north `(186.5, 72, -389.5)` to south `(186.5, 72, -347.5)`. Accepted actual endpoints ranged from `z = -347.092` to `z = -346.548`, or approximately 42.41 to 42.95 blocks of forward movement.
+- Requested traversal time: 4,450 ms.
+- Camera: yaw 0 degrees, pitch 12 degrees.
+- Repetitions: four accepted runs per build.
+- Comparison: previous CPU-reduction hotfix `9DEF9575...` versus final GPU-mesh hotfix `8B80F1A4...`.
+- Both builds used the same world, route, client profile, video settings, and measurement pipeline.
+
+| Dynamic traversal metric | Previous hotfix | GPU-mesh hotfix | Change |
+| --- | ---: | ---: | ---: |
+| Whole route mean FPS | 27.66 | 32.62 | **+17.9%** |
+| North third mean FPS | 25.07 | 31.28 | **+24.8%** |
+| Middle third mean FPS | 27.43 | 31.45 | **+14.7%** |
+| South third mean FPS | 30.46 | 35.14 | **+15.4%** |
+| Mean whole-route p95 frame time | 44.46 ms | 43.53 ms | **-2.1%** |
+
+The primary result is the four-run whole-route mean of **27.66 to 32.62 FPS (+17.9%)**. The first GPU-mesh run was retained rather than discarded; the three subsequent warm runs averaged approximately 34.0 FPS.
+
+These numbers are workload- and profile-specific. Absolute FPS should not be generalized to other maps, view distances, GPUs, or modpacks.
+
+### Test profile
+
+- CPU: AMD Ryzen 9 8940HX.
+- GPU: NVIDIA GeForce RTX 5060 Laptop GPU.
+- Renderer: OpenGL 3.2, NVIDIA 596.49.
+- Compatibility stack present during testing: JCM 2.2.3, Sodium 0.5.13, Sodium Extra 0.5.9, Entity Culling 1.9.0, and ImmediatelyFast 1.5.5.
+
+### Prior field observation
+
+Before the controlled local-map benchmark, the user observed FPS increasing from approximately 18 to 24 (+33.3%) while connected to the dedicated server at a very large station with an earlier modified build. That observation used a different build and did not have the same route, repetition, or coordinate validation. It is included as field context only and is not attributed to the final `8B80F1A4...` build or combined with the controlled result.
+
+## Why It Helps
+
+The original rail path runs `railMath.render`, visibility calculations, quad construction, `BufferBuilder`, and vertex submission for a large number of rail segments on the client render thread every frame. A single saturated render thread can therefore limit FPS even when total CPU and GPU utilization remain low.
+
+The hotfix changes that path as follows:
+
+1. Only normal, default-style, two-dimensional `TRAIN` rails enter the cache. Custom styles, multiple styles, 3D rails, edit previews, and unsupported transport modes keep the legacy renderer.
+2. Rail geometry is still tessellated at 0.5 m intervals, but it is divided into pages of 128 segments, nominally 64 m per page.
+3. Geometry preparation runs on one or two daemon worker threads, depending on available processors.
+4. Prepared pages are uploaded on the render thread because OpenGL resources are render-context-bound. Uploads are limited to eight pages per frame with a soft approximately 2 ms per-frame budget after the first upload.
+5. Uploaded pages are reused as static GPU meshes on later frames. The render thread then performs page visibility selection and queues existing meshes instead of rebuilding every rail quad.
+6. Page-local coordinates preserve float precision at large world coordinates, and block/sky light is retained per rail segment when a page is uploaded.
+7. The estimated mesh cache is capped at 128 MiB and evicts older entries when it exceeds that budget.
+8. Rail geometry changes, removed rails, chunk loads, light-section updates, resource reloads, disconnects, resets, and world changes invalidate the affected cache state.
+9. Until a page is ready, or if a rail is ineligible or preparation/upload fails, rendering falls back to the original path rather than omitting the rail.
+
+This is not multithreaded OpenGL and it does not use NVIDIA-specific APIs. The gain comes from moving repeatable CPU geometry preparation off the render thread and, more importantly, retaining static geometry on the GPU so it is not rebuilt every frame.
+
+JCM rail-level occlusion selection remains in place before cached rails are considered. Compatibility tests also preserve the compiler-generated MTR methods and local-variable layout used by JCM 2.2.3 mixins.
+
+## Profiling Evidence
+
+Matched Java Flight Recorder samples show that the controlled FPS change corresponds to removal of repeated rail work from the render thread:
+
+| JFR render-thread metric | Previous hotfix | GPU-mesh hotfix | Relative change |
+| --- | ---: | ---: | ---: |
+| Samples under `RenderRails` | 34.41% | 2.70% | -92.2% |
+| Samples under legacy `renderRailStandard` | 33.33% | 0.60% | -98.2% |
+| Samples under `BufferBuilder.nextElement` | 16.13% | 0.30% | -98.1% |
+| Sampled allocation volume attributed to rail rendering | 435.9 MiB | 6.0 MiB | -98.6% |
+
+The first three rows are shares of JFR render-thread execution samples, not absolute CPU time. The allocation row is JFR sampled allocation volume, not total heap allocation.
+
+## Supporting Changes
+
+The branch also retains the preceding hotfix work around the mesh cache:
+
+- Allocation-light fallback rail visibility math with equivalence tests around distance and camera-facing boundaries.
+- No unused rail or vehicle occlusion-task construction during shadow passes.
+- Coalesced asynchronous dynamic-texture generation, stale-result rejection, retry backoff, and explicit image/texture ownership.
+- Fewer redundant route-panel block scans and duplicate APG route rendering.
+- Nested optimized-renderer reload handling and GL state preservation for incremental mesh uploads.
+- Reuse of serialized broadcast packet content instead of serializing once per player.
+
+The controlled `+17.9%` comparison isolates the final GPU-mesh build from the previous hotfix build; it is not a measurement of every supporting change against unmodified upstream.
+
+## Known Limits
+
+- The 128 MiB cache limit is estimated accounting, not a strict VRAM or total-memory limit.
+- An exceptionally long single rail is prepared before its estimated size is checked. It can therefore cause a temporary preparation-memory peak before being rejected and returned to the legacy renderer. The tested D3 scene did not trigger this case.
+- Nearby-rail prewarming scans the currently known rail wrappers each frame. Extremely large networks can therefore retain some render-thread scaling cost even after mesh caching.
+- Iris and other shader packs were not included in the validated profile.
+- OpenGL upload remains render-thread work, and the first page uploaded in a frame can exceed the soft time budget. The cache removes the repeated per-frame cost after upload; it does not make initial upload free.
+
+## Build And Verification
+
+Build with Java 21:
+
+```shell
+./gradlew -PminecraftVersion=1.20.1 :fabric:clean :fabric:setupFiles :fabric:test :fabric:build
+```
+
+Final verification:
+
+- Fabric clean build completed successfully.
+- 38 tests passed with 0 failures and 0 errors.
+- Exact rebuilt jar: `fabric/build/libs/fabric-4.0.5.jar`.
+- SHA-256: `8B80F1A451F9DF6D5D892CDDB5B32C641098E4989B83A906FC2236A62DF470A0`.
+- The rebuilt jar is byte-for-byte identical to the artifact used for the reported D3 benchmark.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "java"
-	id "com.github.johnrengelman.shadow" version "+" apply false
+	id "com.github.johnrengelman.shadow" version "8.1.1" apply false
 }
 
 group "org.mtr.mod"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 }
 
 repositories {
-	maven { url = "https://maven.terraformersmc.com/" }
+	maven { url = "https://maven.terraformersmc.com/releases/" }
 }
 
 java {

--- a/fabric/src/main/java/org/mtr/mod/InitClient.java
+++ b/fabric/src/main/java/org/mtr/mod/InitClient.java
@@ -392,6 +392,7 @@ public final class InitClient {
 		});
 
 		REGISTRY_CLIENT.eventRegistryClient.registerClientDisconnect(() -> {
+			DefaultRailMeshCache.clear();
 			if (webserver != null) {
 				webserver.stop();
 				webserver = null;
@@ -449,11 +450,12 @@ public final class InitClient {
 		});
 
 		REGISTRY_CLIENT.eventRegistryClient.registerChunkLoad((clientWorld, worldChunk) -> {
+			final ChunkPos chunkPos = worldChunk.getPos();
+			DefaultRailMeshCache.invalidateChunk(chunkPos.getXMapped(), chunkPos.getZMapped());
 			if (lastUpdatePacketMillis == 0) {
 				lastUpdatePacketMillis = getGameMillis() + 500;
 			}
 		});
-
 		REGISTRY_CLIENT.eventRegistryClient.registerResourceReloadEvent(CustomResourceLoader::reload);
 
 		REGISTRY_CLIENT.eventRegistryClient.registerGuiRendering(DrivingGuiRenderer::render);
@@ -500,7 +502,7 @@ public final class InitClient {
 
 	public static void findClosePlatform(BlockPos blockPos, int radius, Consumer<Platform> consumer) {
 		final Position position = Init.blockPosToPosition(blockPos);
-		MinecraftClientData.getInstance().platforms.stream().filter(platform -> platform.closeTo(Init.blockPosToPosition(blockPos), radius)).min(Comparator.comparingDouble(platform -> platform.getApproximateClosestDistance(position, MinecraftClientData.getInstance()))).ifPresent(consumer);
+		MinecraftClientData.getInstance().platforms.stream().filter(platform -> platform.closeTo(position, radius)).min(Comparator.comparingDouble(platform -> platform.getApproximateClosestDistance(position, MinecraftClientData.getInstance()))).ifPresent(consumer);
 	}
 
 	@Nullable

--- a/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
+++ b/fabric/src/main/java/org/mtr/mod/client/CustomResourceLoader.java
@@ -11,6 +11,7 @@ import org.mtr.mapping.mapper.ResourceManagerHelper;
 import org.mtr.mod.Init;
 import org.mtr.mod.Keys;
 import org.mtr.mod.config.Config;
+import org.mtr.mod.render.DefaultRailMeshCache;
 import org.mtr.mod.resource.*;
 
 import java.io.InputStream;
@@ -70,6 +71,8 @@ public class CustomResourceLoader {
 	}
 
 	public static void reload() {
+		OPTIMIZED_RENDERER_WRAPPER.markReloadRequired();
+		DefaultRailMeshCache.clear();
 		MINECRAFT_MODEL_RESOURCES.clear();
 		MINECRAFT_TEXTURE_RESOURCES.clear();
 		RESOURCE_CACHE.clear();

--- a/fabric/src/main/java/org/mtr/mod/client/DynamicTextureCache.java
+++ b/fabric/src/main/java/org/mtr/mod/client/DynamicTextureCache.java
@@ -4,10 +4,10 @@ import org.mtr.core.servlet.MessageQueue;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2LongArrayMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.ResourceManagerHelper;
 import org.mtr.mod.Init;
+import org.mtr.mod.config.Client;
 import org.mtr.mod.config.Config;
 import org.mtr.mod.config.LanguageDisplay;
 import org.mtr.mod.data.IGui;
@@ -31,14 +31,17 @@ public class DynamicTextureCache implements IGui {
 	private Font fontCjk;
 
 	private final Object2ObjectLinkedOpenHashMap<String, DynamicResource> dynamicResources = new Object2ObjectLinkedOpenHashMap<>();
-	private final ObjectOpenHashSet<String> generatingResources = new ObjectOpenHashSet<>();
+	private final DynamicTextureGenerationTracker generationTracker = new DynamicTextureGenerationTracker();
 	private final MessageQueue<Runnable> resourceRegistryQueue = new MessageQueue<>();
-	private final Object2LongArrayMap<Identifier> deletedResources = new Object2LongArrayMap<>();
+	private final Object2ObjectLinkedOpenHashMap<Identifier, NativeImageBackedTexture> deletedResources = new Object2ObjectLinkedOpenHashMap<>();
+	private final Object2LongArrayMap<Identifier> deletedResourceExpiryTimes = new Object2LongArrayMap<>();
 
 	public static DynamicTextureCache instance = new DynamicTextureCache();
 
 	public static final float LINE_HEIGHT_MULTIPLIER = 1.25F;
 	private static final int COOLDOWN_TIME = 10000; // Images not requested within the last 10 seconds will be unregistered
+	private static final int FAILURE_RETRY_TIME = 1000;
+	private static final String DYNAMIC_TEXTURE_NAME = Init.MOD_ID + "_dynamic_texture";
 	private static final Identifier DEFAULT_BLACK_RESOURCE = new Identifier(Init.MOD_ID, "textures/block/black.png");
 	private static final Identifier DEFAULT_WHITE_RESOURCE = new Identifier(Init.MOD_ID, "textures/block/white.png");
 	private static final Identifier DEFAULT_TRANSPARENT_RESOURCE = new Identifier(Init.MOD_ID, "textures/block/transparent.png");
@@ -59,7 +62,7 @@ public class DynamicTextureCache implements IGui {
 	public void refresh() {
 		Init.LOGGER.debug("Refreshing dynamic resources; {} textures in memory; {} textures queued to be destroyed", dynamicResources.size(), deletedResources.size());
 		dynamicResources.values().forEach(dynamicResource -> dynamicResource.needsRefresh = true);
-		generatingResources.clear();
+		generationTracker.refresh();
 	}
 
 	public void tick() {
@@ -68,20 +71,23 @@ public class DynamicTextureCache implements IGui {
 		dynamicResources.forEach((checkKey, checkDynamicResource) -> {
 			if (checkDynamicResource.expiryTime < currentTimeMillis) {
 				checkDynamicResource.remove();
-				deletedResources.put(checkDynamicResource.identifier, currentTimeMillis + COOLDOWN_TIME);
+				queueResourceForDeletion(checkDynamicResource, currentTimeMillis);
 				keysToRemove.add(checkKey);
 			}
 		});
 		keysToRemove.forEach(dynamicResources::remove);
 
 		final ObjectArrayList<Identifier> deletedResourcesToRemove = new ObjectArrayList<>();
-		deletedResources.forEach((identifier, expiryTime) -> {
+		deletedResourceExpiryTimes.forEach((identifier, expiryTime) -> {
 			if (expiryTime < currentTimeMillis) {
-				MinecraftClient.getInstance().getTextureManager().destroyTexture(identifier);
+				destroyTexture(identifier, deletedResources.get(identifier));
 				deletedResourcesToRemove.add(identifier);
 			}
 		});
-		deletedResourcesToRemove.forEach(deletedResources::removeLong);
+		deletedResourcesToRemove.forEach(identifier -> {
+			deletedResources.remove(identifier);
+			deletedResourceExpiryTimes.removeLong(identifier);
+		});
 	}
 
 	public DynamicResource getPixelatedText(String text, int textColor, int maxWidth, double cjkSizeRatio, boolean fullPixel) {
@@ -232,18 +238,36 @@ public class DynamicTextureCache implements IGui {
 
 	private DynamicResource getResource(String key, Supplier<NativeImage> supplier, DefaultRenderingColor defaultRenderingColor) {
 		resourceRegistryQueue.process(Runnable::run);
+		final long currentTimeMillis = System.currentTimeMillis();
 		final DynamicResource dynamicResource = dynamicResources.get(key);
 
 		if (dynamicResource != null && !dynamicResource.needsRefresh) {
-			dynamicResource.expiryTime = System.currentTimeMillis() + COOLDOWN_TIME;
+			dynamicResource.expiryTime = currentTimeMillis + COOLDOWN_TIME;
 			return dynamicResource;
 		}
 
-		if (generatingResources.contains(key)) {
-			return defaultRenderingColor.dynamicResource;
+		if (generationTracker.isActive(key) || generationTracker.isRetryBlocked(key, currentTimeMillis)) {
+			return getExistingOrDefault(dynamicResource, defaultRenderingColor, currentTimeMillis);
 		}
 
-		MainRenderer.WORKER_THREAD.scheduleDynamicTextures(() -> {
+		final DynamicTextureGenerationTracker.Token generationToken = generationTracker.start(key);
+		boolean generationScheduled = false;
+		try {
+			RouteMapGenerator.setConstants();
+			MainRenderer.WORKER_THREAD.scheduleDynamicTextures(() -> generateResource(key, generationToken, supplier));
+			generationScheduled = true;
+		} finally {
+			if (!generationScheduled) {
+				generationTracker.completeFailure(key, generationToken, currentTimeMillis + FAILURE_RETRY_TIME);
+			}
+		}
+		return getExistingOrDefault(dynamicResource, defaultRenderingColor, currentTimeMillis);
+	}
+
+	private void generateResource(String key, DynamicTextureGenerationTracker.Token generationToken, Supplier<NativeImage> supplier) {
+		NativeImage nativeImage = null;
+		boolean registryTaskQueued = false;
+		try {
 			while (font == null) {
 				ResourceManagerHelper.readResource(new Identifier(Init.MOD_ID, "font/noto-sans-semibold.ttf"), inputStream -> {
 					try {
@@ -264,49 +288,147 @@ public class DynamicTextureCache implements IGui {
 				});
 			}
 
-			final NativeImage nativeImage = supplier.get();
-
-			resourceRegistryQueue.put(() -> {
-				final DynamicResource staticTextureProviderOld = dynamicResources.get(key);
-				if (staticTextureProviderOld != null) {
-					staticTextureProviderOld.remove();
-					deletedResources.put(staticTextureProviderOld.identifier, System.currentTimeMillis() + COOLDOWN_TIME);
-				}
-
-				final DynamicResource dynamicResourceNew;
+			nativeImage = supplier.get();
+			final NativeImage nativeImageToRegister = nativeImage;
+			resourceRegistryQueue.put(() -> registerResource(key, generationToken, nativeImageToRegister));
+			registryTaskQueued = true;
+		} finally {
+			if (!registryTaskQueued) {
 				if (nativeImage != null) {
-					final NativeImage newNativeImage;
-					final int newMaxImageSize = MAX_IMAGE_SIZE * (int) Math.pow(2, Config.getClient().getDynamicTextureResolution());
-					if (nativeImage.getWidth() > newMaxImageSize || nativeImage.getHeight() > newMaxImageSize) {
-						newNativeImage = new NativeImage(NativeImageFormat.getAbgrMapped(), Math.min(newMaxImageSize, nativeImage.getWidth()), Math.min(newMaxImageSize, nativeImage.getHeight()), false);
-						for (int x = 0; x < Math.min(newMaxImageSize, nativeImage.getWidth()); x++) {
-							for (int y = 0; y < Math.min(newMaxImageSize, nativeImage.getHeight()); y++) {
-								newNativeImage.setPixelColor(x, y, nativeImage.getColor(x, y));
-							}
-						}
-					} else {
-						newNativeImage = nativeImage;
-					}
-
-					final NativeImageBackedTexture nativeImageBackedTexture = new NativeImageBackedTexture(newNativeImage);
-					final Identifier identifier = new Identifier(Init.MOD_ID, "id_" + Init.randomString());
-					MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, new AbstractTexture(nativeImageBackedTexture.data));
-					dynamicResourceNew = new DynamicResource(identifier, nativeImageBackedTexture);
-					dynamicResources.put(key, dynamicResourceNew);
+					nativeImage.close();
 				}
+				resourceRegistryQueue.put(() -> completeFailedGeneration(key, generationToken));
+			}
+		}
+	}
 
-				generatingResources.remove(key);
-			});
-		});
-		RouteMapGenerator.setConstants();
-		generatingResources.add(key);
+	private void registerResource(String key, DynamicTextureGenerationTracker.Token generationToken, @Nullable NativeImage nativeImage) {
+		if (!generationTracker.isCurrent(key, generationToken)) {
+			if (nativeImage != null) {
+				nativeImage.close();
+			}
+			return;
+		}
 
+		if (nativeImage == null) {
+			completeFailedGeneration(key, generationToken);
+			return;
+		}
+
+		DynamicResource dynamicResourceNew = null;
+		boolean resourceInstalled = false;
+		try {
+			dynamicResourceNew = registerTexture(nativeImage);
+			final long currentTimeMillis = System.currentTimeMillis();
+			dynamicResourceNew.expiryTime = currentTimeMillis + COOLDOWN_TIME;
+			final DynamicResource dynamicResourceOld = dynamicResources.put(key, dynamicResourceNew);
+			resourceInstalled = true;
+			if (dynamicResourceOld != null) {
+				try {
+					dynamicResourceOld.remove();
+				} finally {
+					queueResourceForDeletion(dynamicResourceOld, currentTimeMillis);
+				}
+			}
+		} catch (RuntimeException e) {
+			Init.LOGGER.error("Unable to register dynamic texture", e);
+		} finally {
+			if (!resourceInstalled && dynamicResourceNew != null) {
+				destroyResource(dynamicResourceNew);
+			}
+			if (resourceInstalled) {
+				generationTracker.completeSuccess(key, generationToken);
+			} else {
+				generationTracker.completeFailure(key, generationToken, System.currentTimeMillis() + FAILURE_RETRY_TIME);
+			}
+		}
+	}
+
+	private DynamicResource registerTexture(NativeImage nativeImage) {
+		NativeImage ownedImage = nativeImage;
+		NativeImageBackedTexture ownedTexture = null;
+		Identifier registeredIdentifier = null;
+		try {
+			final int dynamicTextureResolution = Math.max(0, Math.min(Client.DYNAMIC_RESOLUTION_COUNT, Config.getClient().getDynamicTextureResolution()));
+			final int newMaxImageSize = MAX_IMAGE_SIZE << dynamicTextureResolution;
+			if (ownedImage.getWidth() > newMaxImageSize || ownedImage.getHeight() > newMaxImageSize) {
+				final int width = Math.min(newMaxImageSize, ownedImage.getWidth());
+				final int height = Math.min(newMaxImageSize, ownedImage.getHeight());
+				final NativeImage resizedImage = new NativeImage(NativeImageFormat.getAbgrMapped(), width, height, false);
+				boolean copySucceeded = false;
+				try {
+					for (int x = 0; x < width; x++) {
+						for (int y = 0; y < height; y++) {
+							resizedImage.setPixelColor(x, y, ownedImage.getColor(x, y));
+						}
+					}
+					copySucceeded = true;
+				} finally {
+					if (!copySucceeded) {
+						resizedImage.close();
+					}
+				}
+				final NativeImage originalImage = ownedImage;
+				ownedImage = resizedImage;
+				originalImage.close();
+			}
+
+			ownedTexture = new NativeImageBackedTexture(ownedImage);
+			ownedImage = null;
+			registeredIdentifier = MinecraftClient.getInstance().getTextureManager().registerDynamicTexture(DYNAMIC_TEXTURE_NAME, ownedTexture);
+			final DynamicResource dynamicResource = new DynamicResource(registeredIdentifier, ownedTexture);
+			ownedTexture = null;
+			registeredIdentifier = null;
+			return dynamicResource;
+		} finally {
+			if (ownedTexture != null) {
+				if (registeredIdentifier == null) {
+					ownedTexture.close();
+				} else {
+					destroyTexture(registeredIdentifier, ownedTexture);
+				}
+			}
+			if (ownedImage != null) {
+				ownedImage.close();
+			}
+		}
+	}
+
+	private DynamicResource getExistingOrDefault(@Nullable DynamicResource dynamicResource, DefaultRenderingColor defaultRenderingColor, long currentTimeMillis) {
 		if (dynamicResource == null) {
 			return defaultRenderingColor.dynamicResource;
-		} else {
-			dynamicResource.expiryTime = System.currentTimeMillis() + COOLDOWN_TIME;
-			dynamicResource.needsRefresh = false;
-			return dynamicResource;
+		}
+		dynamicResource.expiryTime = currentTimeMillis + COOLDOWN_TIME;
+		return dynamicResource;
+	}
+
+	private void completeFailedGeneration(String key, DynamicTextureGenerationTracker.Token generationToken) {
+		generationTracker.completeFailure(key, generationToken, System.currentTimeMillis() + FAILURE_RETRY_TIME);
+	}
+
+	private void queueResourceForDeletion(DynamicResource dynamicResource, long currentTimeMillis) {
+		if (dynamicResource.texture != null) {
+			deletedResources.put(dynamicResource.identifier, dynamicResource.texture);
+			deletedResourceExpiryTimes.put(dynamicResource.identifier, currentTimeMillis + COOLDOWN_TIME);
+		}
+	}
+
+	private static void destroyResource(DynamicResource dynamicResource) {
+		destroyTexture(dynamicResource.identifier, dynamicResource.texture);
+	}
+
+	private static void destroyTexture(Identifier identifier, @Nullable NativeImageBackedTexture texture) {
+		try {
+			MinecraftClient.getInstance().getTextureManager().destroyTexture(identifier);
+		} catch (RuntimeException e) {
+			Init.LOGGER.error("Unable to destroy dynamic texture", e);
+		}
+		if (texture != null) {
+			try {
+				texture.close();
+			} catch (RuntimeException e) {
+				Init.LOGGER.error("Unable to close dynamic texture", e);
+			}
 		}
 	}
 
@@ -314,12 +436,14 @@ public class DynamicTextureCache implements IGui {
 
 		private long expiryTime;
 		private boolean needsRefresh;
+		private final NativeImageBackedTexture texture;
 		public final int width;
 		public final int height;
 		public final Identifier identifier;
 
 		private DynamicResource(Identifier identifier, @Nullable NativeImageBackedTexture nativeImageBackedTexture) {
 			this.identifier = identifier;
+			texture = nativeImageBackedTexture;
 			if (nativeImageBackedTexture != null) {
 				final NativeImage nativeImage = nativeImageBackedTexture.getImage();
 				if (nativeImage != null) {

--- a/fabric/src/main/java/org/mtr/mod/client/DynamicTextureGenerationTracker.java
+++ b/fabric/src/main/java/org/mtr/mod/client/DynamicTextureGenerationTracker.java
@@ -1,0 +1,57 @@
+package org.mtr.mod.client;
+
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2LongArrayMap;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+
+final class DynamicTextureGenerationTracker {
+
+	private final Object2ObjectLinkedOpenHashMap<String, Token> activeGenerations = new Object2ObjectLinkedOpenHashMap<>();
+	private final Object2LongArrayMap<String> retryTimes = new Object2LongArrayMap<>();
+
+	Token start(String key) {
+		final Token token = new Token();
+		activeGenerations.put(key, token);
+		return token;
+	}
+
+	boolean isActive(String key) {
+		return activeGenerations.containsKey(key);
+	}
+
+	boolean isCurrent(String key, Token token) {
+		return activeGenerations.get(key) == token;
+	}
+
+	boolean isRetryBlocked(String key, long currentTimeMillis) {
+		if (!retryTimes.containsKey(key)) {
+			return false;
+		}
+		if (retryTimes.getLong(key) > currentTimeMillis) {
+			return true;
+		}
+		retryTimes.removeLong(key);
+		return false;
+	}
+
+	void completeSuccess(String key, Token token) {
+		if (isCurrent(key, token)) {
+			activeGenerations.remove(key);
+			retryTimes.removeLong(key);
+		}
+	}
+
+	void completeFailure(String key, Token token, long retryTime) {
+		if (isCurrent(key, token)) {
+			activeGenerations.remove(key);
+			retryTimes.put(key, retryTime);
+		}
+	}
+
+	void refresh() {
+		activeGenerations.clear();
+		retryTimes.clear();
+	}
+
+	static final class Token {
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/client/MinecraftClientData.java
+++ b/fabric/src/main/java/org/mtr/mod/client/MinecraftClientData.java
@@ -14,6 +14,7 @@ import org.mtr.mod.Init;
 import org.mtr.mod.block.BlockNode;
 import org.mtr.mod.data.PersistentVehicleData;
 import org.mtr.mod.data.VehicleExtension;
+import org.mtr.mod.render.DefaultRailMeshCache;
 import org.mtr.mod.screen.DashboardListItem;
 
 import javax.annotation.Nullable;
@@ -68,12 +69,17 @@ public final class MinecraftClientData extends ClientData {
 		positionsToRail.forEach((startPosition, railMap) -> railMap.forEach((endPosition, rail) -> {
 			final String hexId = rail.getHexId();
 			final RailWrapper railWrapper = railWrapperList.get(hexId);
-			if (railWrapper == null) {
-				railWrapperList.put(hexId, new RailWrapper(rail, hexId));
-			} else {
-				railWrapper.rail = rail;
+			if (railWrapper == null || railWrapper.rail != rail) {
+				final RailWrapper newRailWrapper = new RailWrapper(rail, hexId);
+				if (railWrapper != null) {
+					newRailWrapper.shouldRender = railWrapper.shouldRender;
+				}
+				railWrapperList.put(hexId, newRailWrapper);
 			}
 		}));
+		if (this == getInstance()) {
+			DefaultRailMeshCache.reconcile(railWrapperList.values());
+		}
 
 		simplifiedRoutes.forEach(simplifiedRoute -> simplifiedRouteIdMap.put(simplifiedRoute.getId(), simplifiedRoute));
 	}
@@ -142,6 +148,7 @@ public final class MinecraftClientData extends ClientData {
 	}
 
 	public static void reset() {
+		DefaultRailMeshCache.clear();
 		MinecraftClientData.instance = new MinecraftClientData();
 		MinecraftClientData.dashboardInstance = new MinecraftClientData();
 	}

--- a/fabric/src/main/java/org/mtr/mod/mixin/ClientChunkLightUpdateMixin.java
+++ b/fabric/src/main/java/org/mtr/mod/mixin/ClientChunkLightUpdateMixin.java
@@ -1,0 +1,19 @@
+package org.mtr.mixin;
+
+import net.minecraft.client.world.ClientChunkManager;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.LightType;
+import org.mtr.mod.render.DefaultRailMeshCache;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientChunkManager.class)
+public abstract class ClientChunkLightUpdateMixin {
+
+	@Inject(method = "onLightUpdate", at = @At("TAIL"))
+	private void invalidateDefaultRailLight(LightType lightType, ChunkSectionPos chunkSectionPos, CallbackInfo callbackInfo) {
+		DefaultRailMeshCache.invalidateLightSection(chunkSectionPos.getSectionX(), chunkSectionPos.getSectionY(), chunkSectionPos.getSectionZ());
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/packet/PacketRequestResponseBase.java
+++ b/fabric/src/main/java/org/mtr/mod/packet/PacketRequestResponseBase.java
@@ -57,7 +57,13 @@ public abstract class PacketRequestResponseBase extends PacketHandler {
 					Init.REGISTRY.sendPacketToClient(serverPlayerEntity, getInstance(responseJson.toString()));
 				}
 			} else {
-				MinecraftServerHelper.iteratePlayers(serverWorld, serverPlayerEntityNew -> Init.REGISTRY.sendPacketToClient(serverPlayerEntityNew, getInstance(responseJson.toString())));
+				final String[] responseContent = {null};
+				MinecraftServerHelper.iteratePlayers(serverWorld, serverPlayerEntityNew -> {
+					if (responseContent[0] == null) {
+						responseContent[0] = responseJson.toString();
+					}
+					Init.REGISTRY.sendPacketToClient(serverPlayerEntityNew, getInstance(responseContent[0]));
+				});
 			}
 			runServerInbound(serverWorld, responseJson);
 		}, SerializedDataBase.class);

--- a/fabric/src/main/java/org/mtr/mod/render/DefaultRailMeshCache.java
+++ b/fabric/src/main/java/org/mtr/mod/render/DefaultRailMeshCache.java
@@ -1,0 +1,876 @@
+package org.mtr.mod.render;
+
+import org.mtr.core.data.Rail;
+import org.mtr.core.data.TransportMode;
+import org.mtr.libraries.it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.mapping.holder.*;
+import org.mtr.mapping.mapper.GraphicsHolder;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.mapper.OptimizedRenderer;
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.model.Mesh;
+import org.mtr.mapping.render.model.RawMesh;
+import org.mtr.mapping.render.object.IndexBuffer;
+import org.mtr.mapping.render.object.VertexArray;
+import org.mtr.mapping.render.object.VertexBuffer;
+import org.mtr.mapping.render.vertex.Vertex;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeSource;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+import org.mtr.mapping.mapper.MinecraftClientHelper;
+import org.mtr.mod.Init;
+import org.mtr.mod.client.CustomResourceLoader;
+import org.mtr.mod.client.MinecraftClientData;
+import org.mtr.mod.config.Config;
+import org.mtr.mod.data.IGui;
+
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+public final class DefaultRailMeshCache implements IGui {
+
+	static final double PAGE_LENGTH_METERS = 64;
+	static final int SEGMENTS_PER_PAGE = 128;
+	private static final int MAX_PREPARES_PER_FRAME = 16;
+	private static final int MAX_OUTSTANDING_PREPARES = 16;
+	private static final int MAX_PROACTIVE_OUTSTANDING = 2;
+	private static final int MAX_PAGE_UPLOADS_PER_FRAME = 8;
+	private static final long UPLOAD_BUDGET_NANOS = 2_000_000;
+	private static final long MAX_CACHE_BYTES = 128L * 1024 * 1024;
+	private static final long ESTIMATED_BYTES_PER_SEGMENT = 352;
+	private static final float RAIL_Y_OFFSET = 0.065625F;
+	private static final double LIGHT_REFERENCE_OFFSET = 0.1;
+	static final VertexAttributeMapping RAIL_MAPPING = new VertexAttributeMapping.Builder()
+			.set(VertexAttributeType.POSITION, VertexAttributeSource.VERTEX_BUFFER)
+			.set(VertexAttributeType.COLOR, VertexAttributeSource.GLOBAL)
+			.set(VertexAttributeType.UV_TEXTURE, VertexAttributeSource.VERTEX_BUFFER)
+			.set(VertexAttributeType.UV_OVERLAY, VertexAttributeSource.GLOBAL)
+			.set(VertexAttributeType.UV_LIGHTMAP, VertexAttributeSource.VERTEX_BUFFER)
+			.set(VertexAttributeType.NORMAL, VertexAttributeSource.VERTEX_BUFFER)
+			.set(VertexAttributeType.MATRIX_MODEL, VertexAttributeSource.GLOBAL)
+			.build();
+	private static final MaterialProperties RAIL_MATERIAL = new MaterialProperties(OptimizedModel.ShaderType.CUTOUT, new Identifier("textures/block/rail.png"), null);
+	private static final LinkedHashMap<String, CacheEntry> CACHE = new LinkedHashMap<>(256, 0.75F, false);
+	private static final Map<String, PreparingEntry> PREPARING = new HashMap<>();
+	private static final Map<String, Rail> FAILED_RAILS = new HashMap<>();
+	private static final Set<String> DEFERRED_REMOVALS = new HashSet<>();
+	private static final ObjectArrayList<UploadedPage> VISIBLE_PAGES = new ObjectArrayList<>();
+	private static final ExecutorService PREPARE_EXECUTOR = Executors.newFixedThreadPool(Math.max(1, Math.min(2, Runtime.getRuntime().availableProcessors() / 4)), runnable -> {
+		final Thread thread = new Thread(runnable, "MTR Default Rail Mesh Builder");
+		thread.setDaemon(true);
+		return thread;
+	});
+
+	private static ClientWorld currentWorld;
+	private static long estimatedCacheBytes;
+	private static int preparesThisFrame;
+	private static int pageUploadsThisFrame;
+	private static long uploadDeadlineNanos;
+	private static boolean shadowPass;
+	private static double cameraX;
+	private static double cameraY;
+	private static double cameraZ;
+	private static double renderDistance;
+	private static float yawCos;
+	private static float yawSin;
+	private static float pitchCos;
+	private static float pitchSin;
+
+	static boolean isEligible(boolean normalRenderState, TransportMode transportMode, Iterable<String> styles, boolean defaultRail3D) {
+		if (!normalRenderState || transportMode != TransportMode.TRAIN || defaultRail3D || styles == null) {
+			return false;
+		}
+		final Iterator<String> iterator = styles.iterator();
+		return iterator.hasNext() && CustomResourceLoader.DEFAULT_RAIL_ID.equals(iterator.next()) && !iterator.hasNext();
+	}
+
+	public static void beginFrame(ClientWorld clientWorld, boolean renderingShadows) {
+		VISIBLE_PAGES.clear();
+		DEFERRED_REMOVALS.forEach(DefaultRailMeshCache::removeEntry);
+		DEFERRED_REMOVALS.clear();
+		preparesThisFrame = 0;
+		pageUploadsThisFrame = 0;
+		uploadDeadlineNanos = System.nanoTime() + UPLOAD_BUDGET_NANOS;
+		shadowPass = renderingShadows;
+		if (currentWorld == null || !currentWorld.equals(clientWorld)) {
+			clear();
+			currentWorld = clientWorld;
+		}
+		if (!renderingShadows) {
+			harvestPreparedEntries();
+		}
+		trimToBudget();
+
+		final Camera camera = MinecraftClient.getInstance().getGameRendererMapped().getCamera();
+		final Vector3d cameraPosition = camera.getPos();
+		cameraX = cameraPosition.getXMapped();
+		cameraY = cameraPosition.getYMapped();
+		cameraZ = cameraPosition.getZMapped();
+		renderDistance = MinecraftClientHelper.getRenderDistance() * 16D;
+		final float yaw = (float) Math.toRadians(camera.getYaw());
+		final float pitch = (float) Math.toRadians(camera.getPitch());
+		yawCos = MathHelper.cos(yaw);
+		yawSin = MathHelper.sin(yaw);
+		pitchCos = MathHelper.cos(pitch);
+		pitchSin = MathHelper.sin(pitch);
+	}
+
+	static boolean tryRender(ClientWorld clientWorld, Rail rail, boolean normalRenderState, float railWidth) {
+		if (currentWorld == null || !currentWorld.equals(clientWorld) || !OptimizedRenderer.hasOptimizedRendering() ||
+				!isEligible(normalRenderState, rail.getTransportMode(), rail.getStyles(), Config.getClient().getDefaultRail3D())) {
+			return false;
+		}
+
+		final String id = rail.getHexId();
+		final long fingerprint = getGeometryFingerprint(rail);
+		CacheEntry entry = CACHE.get(id);
+		if (entry != null && entry.fingerprint != fingerprint) {
+			removeEntry(id);
+			entry = null;
+		} else if (entry != null) {
+			CACHE.remove(id);
+			CACHE.put(id, entry);
+			entry.rail = rail;
+		}
+
+		PreparingEntry preparingEntry = PREPARING.get(id);
+		if (preparingEntry != null && preparingEntry.fingerprint != fingerprint) {
+			preparingEntry.cancel();
+			PREPARING.remove(id);
+			preparingEntry = null;
+		} else if (preparingEntry != null) {
+			preparingEntry.proactive = false;
+		}
+		if (entry == null) {
+			if (shadowPass || FAILED_RAILS.get(id) == rail) {
+				return false;
+			}
+			if (preparingEntry == null) {
+				cancelProactivePreparingEntries();
+				if (preparesThisFrame >= MAX_PREPARES_PER_FRAME || PREPARING.size() >= MAX_OUTSTANDING_PREPARES) {
+					return false;
+				}
+				preparesThisFrame++;
+				preparingEntry = new PreparingEntry(rail, fingerprint, PREPARE_EXECUTOR.submit(() -> prepare(rail, railWidth)));
+				PREPARING.put(id, preparingEntry);
+			}
+			if (!preparingEntry.future.isDone()) {
+				return false;
+			}
+			try {
+				final PreparedRail preparedRail = preparingEntry.future.get();
+				PREPARING.remove(id);
+				if (preparedRail == null || preparedRail.pages.isEmpty() || preparedRail.estimatedBytes > MAX_CACHE_BYTES) {
+					FAILED_RAILS.put(id, rail);
+					return false;
+				}
+				entry = new CacheEntry(rail, fingerprint, preparedRail);
+				CACHE.put(id, entry);
+				estimatedCacheBytes += entry.estimatedBytes;
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+				PREPARING.remove(id);
+				return false;
+			} catch (ExecutionException | RuntimeException | Error exception) {
+				PREPARING.remove(id);
+				FAILED_RAILS.put(id, rail);
+				Init.LOGGER.warn("Unable to prepare the cached default rail mesh for {}", id, exception);
+				return false;
+			}
+		}
+
+		if (entry.hasMissingVisiblePages()) {
+			if (shadowPass || pageUploadsThisFrame >= MAX_PAGE_UPLOADS_PER_FRAME || (pageUploadsThisFrame > 0 && System.nanoTime() >= uploadDeadlineNanos)) {
+				return false;
+			}
+			try {
+				pageUploadsThisFrame += entry.uploadMissingVisiblePages(clientWorld, 1, uploadDeadlineNanos);
+			} catch (RuntimeException | Error exception) {
+				removeEntry(id);
+				FAILED_RAILS.put(id, rail);
+				Init.LOGGER.warn("Unable to upload the cached default rail mesh for {}", id, exception);
+				return false;
+			}
+			if (entry.hasMissingVisiblePages()) {
+				return false;
+			}
+		}
+
+		for (final UploadedPage page : entry.pages) {
+			if (page != null && page.isVisible()) {
+				VISIBLE_PAGES.add(page);
+			}
+		}
+		return true;
+	}
+
+	public static void scheduleRender() {
+		if (!VISIBLE_PAGES.isEmpty()) {
+			MainRenderer.scheduleRender(QueuedRenderLayer.TEXT, DefaultRailMeshCache::queueVisiblePages);
+		}
+	}
+
+	public static void finishFrame(ClientWorld clientWorld) {
+		if (shadowPass || currentWorld == null || !currentWorld.equals(clientWorld)) {
+			return;
+		}
+		prewarmNearbyRails();
+		if (pageUploadsThisFrame >= MAX_PAGE_UPLOADS_PER_FRAME || (pageUploadsThisFrame > 0 && System.nanoTime() >= uploadDeadlineNanos)) {
+			return;
+		}
+		for (final Map.Entry<String, CacheEntry> mapEntry : CACHE.entrySet()) {
+			final CacheEntry entry = mapEntry.getValue();
+			if (entry.hasMissingLoadedPages(clientWorld)) {
+				try {
+					final int uploadedPages = entry.uploadMissingPages(clientWorld, 1, uploadDeadlineNanos, false, true);
+					pageUploadsThisFrame += uploadedPages;
+					if (uploadedPages == 0) {
+						continue;
+					}
+				} catch (RuntimeException | Error exception) {
+					FAILED_RAILS.put(mapEntry.getKey(), entry.rail);
+					DEFERRED_REMOVALS.add(mapEntry.getKey());
+					Init.LOGGER.warn("Unable to upload the cached default rail mesh for {}", mapEntry.getKey(), exception);
+				}
+				return;
+			}
+		}
+	}
+
+	public static void reconcile(Iterable<MinecraftClientData.RailWrapper> liveWrappers) {
+		final Set<String> liveIds = new HashSet<>();
+		for (final MinecraftClientData.RailWrapper wrapper : liveWrappers) {
+			final String id = wrapper.hexId;
+			final Rail rail = wrapper.getRail();
+			liveIds.add(id);
+			final CacheEntry entry = CACHE.get(id);
+			if (entry != null) {
+				if (entry.fingerprint == getGeometryFingerprint(rail)) {
+					entry.rail = rail;
+				} else {
+					removeEntry(id);
+				}
+			}
+			final PreparingEntry preparingEntry = PREPARING.get(id);
+			if (preparingEntry != null && preparingEntry.fingerprint != getGeometryFingerprint(rail)) {
+				preparingEntry.cancel();
+				PREPARING.remove(id);
+			}
+			if (FAILED_RAILS.get(id) != rail) {
+				FAILED_RAILS.remove(id);
+			}
+		}
+		removeMissingEntries(liveIds);
+		FAILED_RAILS.keySet().removeIf(id -> !liveIds.contains(id));
+	}
+
+	public static void invalidateChunk(int chunkX, int chunkZ) {
+		invalidateBounds(chunkX * 16D, Double.NEGATIVE_INFINITY, chunkZ * 16D, (chunkX + 1) * 16D, Double.POSITIVE_INFINITY, (chunkZ + 1) * 16D);
+	}
+
+	public static void invalidateLightSection(int sectionX, int sectionY, int sectionZ) {
+		invalidateBounds(sectionX * 16D, sectionY * 16D, sectionZ * 16D, (sectionX + 1) * 16D, (sectionY + 1) * 16D, (sectionZ + 1) * 16D);
+	}
+
+	public static void clear() {
+		PREPARING.values().forEach(PreparingEntry::cancel);
+		PREPARING.clear();
+		CACHE.values().forEach(CacheEntry::close);
+		CACHE.clear();
+		FAILED_RAILS.clear();
+		DEFERRED_REMOVALS.clear();
+		VISIBLE_PAGES.clear();
+		estimatedCacheBytes = 0;
+		currentWorld = null;
+	}
+
+	static int pageIndexForSegment(int segmentIndex) {
+		return segmentIndex / SEGMENTS_PER_PAGE;
+	}
+
+	static int pageCountForSegments(int segmentCount) {
+		return segmentCount <= 0 ? 0 : 1 + (segmentCount - 1) / SEGMENTS_PER_PAGE;
+	}
+
+	static long geometryFingerprint(double angle1, double angle2, Rail.Shape shape, double verticalRadius, double length) {
+		long hash = 0xCBF29CE484222325L;
+		hash = mix(hash, Double.doubleToLongBits(angle1));
+		hash = mix(hash, Double.doubleToLongBits(angle2));
+		hash = mix(hash, shape == null ? -1 : shape.ordinal());
+		hash = mix(hash, Double.doubleToLongBits(verticalRadius));
+		return mix(hash, Double.doubleToLongBits(length));
+	}
+
+	static void appendSegmentVertices(
+			Consumer<Vertex> consumer,
+			double originX, double originY, double originZ,
+			double x1, double z1, double x2, double z2,
+			double x3, double z3, double x4, double z4,
+			double y1, double y2,
+			float yOffset, int light
+	) {
+		final float textureOffset = ((int) (x1 + z1) % 4) * 0.25F;
+		final float v1 = 0.1875F + textureOffset;
+		final float v2 = 0.3125F + textureOffset;
+		final float relativeX1 = (float) (x1 - originX);
+		final float relativeX2 = (float) (x2 - originX);
+		final float relativeX3 = (float) (x3 - originX);
+		final float relativeX4 = (float) (x4 - originX);
+		final float relativeY1 = (float) (y1 - originY) + yOffset;
+		final float relativeY2 = (float) (y2 - originY) + yOffset;
+		final float relativeZ1 = (float) (z1 - originZ);
+		final float relativeZ2 = (float) (z2 - originZ);
+		final float relativeZ3 = (float) (z3 - originZ);
+		final float relativeZ4 = (float) (z4 - originZ);
+
+		consumer.accept(vertex(relativeX1, relativeY1, relativeZ1, 0, v2, light));
+		consumer.accept(vertex(relativeX2, relativeY1 + IGui.SMALL_OFFSET, relativeZ2, 1, v2, light));
+		consumer.accept(vertex(relativeX3, relativeY2, relativeZ3, 1, v1, light));
+		consumer.accept(vertex(relativeX4, relativeY2 + IGui.SMALL_OFFSET, relativeZ4, 0, v1, light));
+		consumer.accept(vertex(relativeX2, relativeY1 + IGui.SMALL_OFFSET, relativeZ2, 0, v2, light));
+		consumer.accept(vertex(relativeX1, relativeY1, relativeZ1, 1, v2, light));
+		consumer.accept(vertex(relativeX4, relativeY2 + IGui.SMALL_OFFSET, relativeZ4, 1, v1, light));
+		consumer.accept(vertex(relativeX3, relativeY2, relativeZ3, 0, v1, light));
+	}
+
+	static boolean isPageVisible(
+			double minX, double minY, double minZ,
+			double maxX, double maxY, double maxZ,
+			double cameraX, double cameraY, double cameraZ,
+			double renderDistance,
+			float yawCos, float yawSin, float pitchCos, float pitchSin
+	) {
+		final double closestX = Math.max(minX, Math.min(maxX, cameraX));
+		final double closestZ = Math.max(minZ, Math.min(maxZ, cameraZ));
+		final double differenceX = closestX - cameraX;
+		final double differenceZ = closestZ - cameraZ;
+		final double distanceSquared = differenceX * differenceX + differenceZ * differenceZ;
+		if (distanceSquared > renderDistance * renderDistance) {
+			return false;
+		}
+		if (distanceSquared <= 32 * 32) {
+			return true;
+		}
+		final double coefficientX = -yawSin * pitchCos;
+		final double coefficientY = -pitchSin;
+		final double coefficientZ = yawCos * pitchCos;
+		final double x = coefficientX >= 0 ? maxX : minX;
+		final double y = coefficientY >= 0 ? maxY : minY;
+		final double z = coefficientZ >= 0 ? maxZ : minZ;
+		return (x - cameraX) * coefficientX + (y - cameraY) * coefficientY + (z - cameraZ) * coefficientZ >= 0;
+	}
+
+	private static PreparedRail prepare(Rail rail, float railWidth) {
+		final ObjectArrayList<PreparedPageBuilder> builders = new ObjectArrayList<>();
+		final PreparedPageBuilder[] currentBuilder = {null};
+		final int[] segmentIndex = {0};
+		rail.railMath.render((x1, z1, x2, z2, x3, z3, x4, z4, y1, y2) -> {
+			if (Thread.currentThread().isInterrupted()) {
+				throw new CancellationException();
+			}
+			if (segmentIndex[0] % SEGMENTS_PER_PAGE == 0) {
+				currentBuilder[0] = new PreparedPageBuilder(x1, Math.min(y1, y2), z1);
+				builders.add(currentBuilder[0]);
+			}
+			currentBuilder[0].addSegment(x1, z1, x2, z2, x3, z3, x4, z4, y1, y2);
+			segmentIndex[0]++;
+		}, 0.5, -railWidth, railWidth);
+
+		if (builders.isEmpty()) {
+			return null;
+		}
+
+		final ObjectArrayList<PreparedPage> pages = new ObjectArrayList<>(builders.size());
+		long estimatedBytes = 0;
+		for (final PreparedPageBuilder builder : builders) {
+			final PreparedPage page = builder.build();
+			pages.add(page);
+			estimatedBytes += page.estimatedBytes;
+		}
+		return pages.isEmpty() ? null : new PreparedRail(pages, estimatedBytes);
+	}
+
+	private static long getGeometryFingerprint(Rail rail) {
+		return geometryFingerprint(
+				rail.getStartAngle(false).angleRadians,
+				rail.getStartAngle(true).angleRadians,
+				rail.railMath.getShape(),
+				rail.railMath.getVerticalRadius(),
+				rail.railMath.getLength()
+		);
+	}
+
+	private static void queueVisiblePages(GraphicsHolder graphicsHolder, Vector3d offset) {
+		for (final UploadedPage page : VISIBLE_PAGES) {
+			graphicsHolder.push();
+			graphicsHolder.translate(page.originX - offset.getXMapped(), page.originY - offset.getYMapped(), page.originZ - offset.getZMapped());
+			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.queue(page.model, graphicsHolder, ARGB_WHITE, GraphicsHolder.getDefaultLight());
+			graphicsHolder.pop();
+		}
+	}
+
+	private static void trimToBudget() {
+		final Iterator<Map.Entry<String, CacheEntry>> iterator = CACHE.entrySet().iterator();
+		while (estimatedCacheBytes > MAX_CACHE_BYTES && iterator.hasNext()) {
+			final CacheEntry entry = iterator.next().getValue();
+			iterator.remove();
+			estimatedCacheBytes -= entry.estimatedBytes;
+			entry.close();
+		}
+	}
+
+	private static void harvestPreparedEntries() {
+		final Iterator<Map.Entry<String, PreparingEntry>> iterator = PREPARING.entrySet().iterator();
+		while (iterator.hasNext()) {
+			final Map.Entry<String, PreparingEntry> mapEntry = iterator.next();
+			final PreparingEntry preparingEntry = mapEntry.getValue();
+			if (!preparingEntry.future.isDone()) {
+				continue;
+			}
+			iterator.remove();
+			try {
+				final PreparedRail preparedRail = preparingEntry.future.get();
+				if (preparedRail == null || preparedRail.pages.isEmpty() || preparedRail.estimatedBytes > MAX_CACHE_BYTES) {
+					FAILED_RAILS.put(mapEntry.getKey(), preparingEntry.rail);
+				} else if (!CACHE.containsKey(mapEntry.getKey())) {
+					final CacheEntry entry = new CacheEntry(preparingEntry.rail, preparingEntry.fingerprint, preparedRail);
+					CACHE.put(mapEntry.getKey(), entry);
+					estimatedCacheBytes += entry.estimatedBytes;
+				}
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+				return;
+			} catch (ExecutionException | RuntimeException | Error exception) {
+				FAILED_RAILS.put(mapEntry.getKey(), preparingEntry.rail);
+				Init.LOGGER.warn("Unable to prepare the cached default rail mesh for {}", mapEntry.getKey(), exception);
+			}
+		}
+	}
+
+	private static void prewarmNearbyRails() {
+		if (!OptimizedRenderer.hasOptimizedRendering() || estimatedCacheBytes >= MAX_CACHE_BYTES) {
+			return;
+		}
+		int proactiveOutstanding = 0;
+		for (final PreparingEntry entry : PREPARING.values()) {
+			if (entry.proactive) {
+				proactiveOutstanding++;
+			}
+		}
+		for (final MinecraftClientData.RailWrapper wrapper : MinecraftClientData.getInstance().railWrapperList.values()) {
+			if (preparesThisFrame >= MAX_PREPARES_PER_FRAME || PREPARING.size() >= MAX_OUTSTANDING_PREPARES || proactiveOutstanding >= MAX_PROACTIVE_OUTSTANDING) {
+				return;
+			}
+			final Rail rail = wrapper.getRail();
+			final String id = rail.getHexId();
+			if (CACHE.containsKey(id) || PREPARING.containsKey(id) || FAILED_RAILS.get(id) == rail ||
+					!isEligible(true, rail.getTransportMode(), rail.getStyles(), Config.getClient().getDefaultRail3D())) {
+				continue;
+			}
+			final double closestX = Math.max(rail.railMath.minX, Math.min(rail.railMath.maxX, cameraX));
+			final double closestZ = Math.max(rail.railMath.minZ, Math.min(rail.railMath.maxZ, cameraZ));
+			final double differenceX = closestX - cameraX;
+			final double differenceZ = closestZ - cameraZ;
+			if (differenceX * differenceX + differenceZ * differenceZ > renderDistance * renderDistance) {
+				continue;
+			}
+			preparesThisFrame++;
+			proactiveOutstanding++;
+			final long fingerprint = getGeometryFingerprint(rail);
+			PREPARING.put(id, new PreparingEntry(rail, fingerprint, PREPARE_EXECUTOR.submit(() -> prepare(rail, 1)), true));
+		}
+	}
+
+	private static void cancelProactivePreparingEntries() {
+		final Iterator<Map.Entry<String, PreparingEntry>> iterator = PREPARING.entrySet().iterator();
+		while (iterator.hasNext()) {
+			final PreparingEntry entry = iterator.next().getValue();
+			if (entry.proactive) {
+				entry.cancel();
+				iterator.remove();
+			}
+		}
+	}
+
+	private static void removeMissingEntries(Set<String> liveIds) {
+		final Iterator<Map.Entry<String, CacheEntry>> iterator = CACHE.entrySet().iterator();
+		while (iterator.hasNext()) {
+			final Map.Entry<String, CacheEntry> mapEntry = iterator.next();
+			if (!liveIds.contains(mapEntry.getKey())) {
+				final CacheEntry entry = mapEntry.getValue();
+				iterator.remove();
+				estimatedCacheBytes -= entry.estimatedBytes;
+				entry.close();
+			}
+		}
+		final Iterator<Map.Entry<String, PreparingEntry>> preparingIterator = PREPARING.entrySet().iterator();
+		while (preparingIterator.hasNext()) {
+			final Map.Entry<String, PreparingEntry> mapEntry = preparingIterator.next();
+			if (!liveIds.contains(mapEntry.getKey())) {
+				mapEntry.getValue().cancel();
+				preparingIterator.remove();
+			}
+		}
+	}
+
+	private static void invalidateBounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		for (final CacheEntry entry : CACHE.values()) {
+			entry.invalidateBounds(minX, minY, minZ, maxX, maxY, maxZ);
+		}
+	}
+
+	private static void removeEntry(String id) {
+		final PreparingEntry preparingEntry = PREPARING.remove(id);
+		if (preparingEntry != null) {
+			preparingEntry.cancel();
+		}
+		final CacheEntry entry = CACHE.remove(id);
+		if (entry != null) {
+			estimatedCacheBytes -= entry.estimatedBytes;
+			entry.close();
+		}
+	}
+
+	private static long mix(long hash, long value) {
+		return (hash ^ value) * 0x100000001B3L;
+	}
+
+	private static Vertex vertex(float x, float y, float z, float u, float v, int light) {
+		final Vertex vertex = new Vertex();
+		vertex.position = new Vector3f(x, y, z);
+		// Vertex equality omits light; subnormal components keep differently lit vertices distinct without changing the rendered normal.
+		vertex.normal = new Vector3f((light & 0xFFFF) * Float.MIN_VALUE, 1, ((light >>> 16) & 0xFFFF) * Float.MIN_VALUE);
+		vertex.u = u;
+		vertex.v = v;
+		vertex.light = light;
+		return vertex;
+	}
+
+	private static final class PreparedPageBuilder {
+
+		private final double originX;
+		private final double originY;
+		private final double originZ;
+		private final DoubleArrayList segments = new DoubleArrayList(SEGMENTS_PER_PAGE * 10);
+		private int segmentCount;
+		private double minX = Double.POSITIVE_INFINITY;
+		private double minY = Double.POSITIVE_INFINITY;
+		private double minZ = Double.POSITIVE_INFINITY;
+		private double maxX = Double.NEGATIVE_INFINITY;
+		private double maxY = Double.NEGATIVE_INFINITY;
+		private double maxZ = Double.NEGATIVE_INFINITY;
+
+		private PreparedPageBuilder(double originX, double originY, double originZ) {
+			this.originX = originX;
+			this.originY = originY;
+			this.originZ = originZ;
+		}
+
+		private void addSegment(double x1, double z1, double x2, double z2, double x3, double z3, double x4, double z4, double y1, double y2) {
+			segments.add(x1);
+			segments.add(z1);
+			segments.add(x2);
+			segments.add(z2);
+			segments.add(x3);
+			segments.add(z3);
+			segments.add(x4);
+			segments.add(z4);
+			segments.add(y1);
+			segments.add(y2);
+			minX = Math.min(minX, Math.min(Math.min(x1, x2), Math.min(x3, x4)));
+			minY = Math.min(minY, Math.min(y1, y2) + RAIL_Y_OFFSET);
+			minZ = Math.min(minZ, Math.min(Math.min(z1, z2), Math.min(z3, z4)));
+			maxX = Math.max(maxX, Math.max(Math.max(x1, x2), Math.max(x3, x4)));
+			maxY = Math.max(maxY, Math.max(y1, y2) + RAIL_Y_OFFSET + IGui.SMALL_OFFSET);
+			maxZ = Math.max(maxZ, Math.max(Math.max(z1, z2), Math.max(z3, z4)));
+
+			final double lightX = Math.floor(x1);
+			final double lightY = Math.floor(y1 + LIGHT_REFERENCE_OFFSET);
+			final double lightZ = Math.floor(z1);
+			minX = Math.min(minX, lightX);
+			minY = Math.min(minY, lightY);
+			minZ = Math.min(minZ, lightZ);
+			maxX = Math.max(maxX, lightX + 1);
+			maxY = Math.max(maxY, lightY + 1);
+			maxZ = Math.max(maxZ, lightZ + 1);
+			segmentCount++;
+		}
+
+		private PreparedPage build() {
+			return new PreparedPage(
+					originX, originY, originZ,
+					minX, minY, minZ, maxX, maxY, maxZ,
+					segments.toDoubleArray(), segmentCount,
+					segmentCount * ESTIMATED_BYTES_PER_SEGMENT
+			);
+		}
+	}
+
+	private static final class PreparedPage {
+
+		private final double originX;
+		private final double originY;
+		private final double originZ;
+		private final double minX;
+		private final double minY;
+		private final double minZ;
+		private final double maxX;
+		private final double maxY;
+		private final double maxZ;
+		private final double[] segments;
+		private final int segmentCount;
+		private final long estimatedBytes;
+
+		private PreparedPage(
+				double originX, double originY, double originZ,
+				double minX, double minY, double minZ,
+				double maxX, double maxY, double maxZ,
+				double[] segments, int segmentCount, long estimatedBytes
+		) {
+			this.originX = originX;
+			this.originY = originY;
+			this.originZ = originZ;
+			this.minX = minX;
+			this.minY = minY;
+			this.minZ = minZ;
+			this.maxX = maxX;
+			this.maxY = maxY;
+			this.maxZ = maxZ;
+			this.segments = segments;
+			this.segmentCount = segmentCount;
+			this.estimatedBytes = estimatedBytes;
+		}
+
+		private boolean intersects(double otherMinX, double otherMinY, double otherMinZ, double otherMaxX, double otherMaxY, double otherMaxZ) {
+			return minX <= otherMaxX && maxX >= otherMinX && minY <= otherMaxY && maxY >= otherMinY && minZ <= otherMaxZ && maxZ >= otherMinZ;
+		}
+
+		private boolean isVisible() {
+			return isPageVisible(minX, minY, minZ, maxX, maxY, maxZ, cameraX, cameraY, cameraZ, renderDistance, yawCos, yawSin, pitchCos, pitchSin);
+		}
+
+		private boolean areChunksLoaded(ClientWorld clientWorld) {
+			final int minChunkX = (int) Math.floor(minX / 16);
+			final int minChunkZ = (int) Math.floor(minZ / 16);
+			final int maxChunkX = (int) Math.floor(Math.nextDown(maxX) / 16);
+			final int maxChunkZ = (int) Math.floor(Math.nextDown(maxZ) / 16);
+			for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+				for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+					if (!clientWorld.getChunkManager().isChunkLoaded(chunkX, chunkZ)) {
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+	}
+
+	private static final class PreparedRail {
+
+		private final ObjectArrayList<PreparedPage> pages;
+		private final long estimatedBytes;
+
+		private PreparedRail(ObjectArrayList<PreparedPage> pages, long estimatedBytes) {
+			this.pages = pages;
+			this.estimatedBytes = estimatedBytes;
+		}
+	}
+
+	private static final class PreparingEntry {
+
+		private final Rail rail;
+		private final long fingerprint;
+		private final Future<PreparedRail> future;
+		private boolean proactive;
+
+		private PreparingEntry(Rail rail, long fingerprint, Future<PreparedRail> future) {
+			this(rail, fingerprint, future, false);
+		}
+
+		private PreparingEntry(Rail rail, long fingerprint, Future<PreparedRail> future, boolean proactive) {
+			this.rail = rail;
+			this.fingerprint = fingerprint;
+			this.future = future;
+			this.proactive = proactive;
+		}
+
+		private void cancel() {
+			future.cancel(true);
+		}
+	}
+
+	private static final class UploadedPage implements AutoCloseable {
+
+		private final double originX;
+		private final double originY;
+		private final double originZ;
+		private final double minX;
+		private final double minY;
+		private final double minZ;
+		private final double maxX;
+		private final double maxY;
+		private final double maxZ;
+		private final Mesh mesh;
+		private final OptimizedModel model;
+		private boolean closed;
+
+		private UploadedPage(PreparedPage page, Mesh mesh, OptimizedModel model) {
+			originX = page.originX;
+			originY = page.originY;
+			originZ = page.originZ;
+			minX = page.minX;
+			minY = page.minY;
+			minZ = page.minZ;
+			maxX = page.maxX;
+			maxY = page.maxY;
+			maxZ = page.maxZ;
+			this.mesh = mesh;
+			this.model = model;
+		}
+
+		private static UploadedPage upload(ClientWorld clientWorld, PreparedPage page) {
+			final RawMesh rawMesh = new RawMesh(RAIL_MATERIAL);
+			final Consumer<Vertex> vertexConsumer = rawMesh::addVertex;
+			for (int offset = 0; offset < page.segments.length; offset += 10) {
+				final double x1 = page.segments[offset];
+				final double z1 = page.segments[offset + 1];
+				final double y1 = page.segments[offset + 8];
+				final BlockPos blockPos = Init.newBlockPos(x1, y1 + LIGHT_REFERENCE_OFFSET, z1);
+				final int light = LightmapTextureManager.pack(
+						clientWorld.getLightLevel(LightType.getBlockMapped(), blockPos),
+						clientWorld.getLightLevel(LightType.getSkyMapped(), blockPos)
+				);
+				appendSegmentVertices(
+						vertexConsumer, page.originX, page.originY, page.originZ,
+						x1, z1, page.segments[offset + 2], page.segments[offset + 3],
+						page.segments[offset + 4], page.segments[offset + 5], page.segments[offset + 6], page.segments[offset + 7],
+						y1, page.segments[offset + 9], RAIL_Y_OFFSET, light
+				);
+			}
+			rawMesh.distinct();
+			rawMesh.triangulate();
+			final Mesh mesh = new Mesh(new VertexBuffer(), new IndexBuffer(rawMesh.faces.size(), 0x1405), RAIL_MATERIAL);
+			VertexArray vertexArray = null;
+			try {
+				rawMesh.upload(mesh, RAIL_MAPPING);
+				vertexArray = new VertexArray(mesh, RAIL_MAPPING);
+				return new UploadedPage(page, mesh, new OptimizedModel(Collections.singletonList(vertexArray)));
+			} catch (RuntimeException | Error exception) {
+				if (vertexArray != null) {
+					vertexArray.close();
+				}
+				mesh.close();
+				throw exception;
+			}
+		}
+
+		private boolean isVisible() {
+			return isPageVisible(minX, minY, minZ, maxX, maxY, maxZ, cameraX, cameraY, cameraZ, renderDistance, yawCos, yawSin, pitchCos, pitchSin);
+		}
+
+		@Override
+		public void close() {
+			if (!closed) {
+				closed = true;
+				model.close();
+				mesh.close();
+			}
+		}
+	}
+
+	private static final class CacheEntry implements AutoCloseable {
+
+		private Rail rail;
+		private final long fingerprint;
+		private final PreparedRail preparedRail;
+		private final ObjectArrayList<UploadedPage> pages;
+		private final long estimatedBytes;
+
+		private CacheEntry(Rail rail, long fingerprint, PreparedRail preparedRail) {
+			this.rail = rail;
+			this.fingerprint = fingerprint;
+			this.preparedRail = preparedRail;
+			this.pages = new ObjectArrayList<>(preparedRail.pages.size());
+			for (int i = 0; i < preparedRail.pages.size(); i++) {
+				pages.add(null);
+			}
+			this.estimatedBytes = preparedRail.estimatedBytes;
+		}
+
+		private boolean hasMissingVisiblePages() {
+			for (int i = 0; i < pages.size(); i++) {
+				if (pages.get(i) == null && preparedRail.pages.get(i).isVisible()) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private int uploadMissingVisiblePages(ClientWorld clientWorld, int maximumPages, long deadlineNanos) {
+			return uploadMissingPages(clientWorld, maximumPages, deadlineNanos, true, false);
+		}
+
+		private boolean hasMissingPages() {
+			for (final UploadedPage page : pages) {
+				if (page == null) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private boolean hasMissingLoadedPages(ClientWorld clientWorld) {
+			for (int i = 0; i < pages.size(); i++) {
+				if (pages.get(i) == null && preparedRail.pages.get(i).areChunksLoaded(clientWorld)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private int uploadMissingPages(ClientWorld clientWorld, int maximumPages, long deadlineNanos, boolean visibleOnly, boolean loadedOnly) {
+			final int[] uploadedCount = {0};
+			final Boolean uploaded = CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.upload(() -> {
+				for (int i = 0; i < pages.size(); i++) {
+					if (pages.get(i) == null && (!visibleOnly || preparedRail.pages.get(i).isVisible()) && (!loadedOnly || preparedRail.pages.get(i).areChunksLoaded(clientWorld))) {
+						if (uploadedCount[0] >= maximumPages || (uploadedCount[0] > 0 && System.nanoTime() >= deadlineNanos)) {
+							break;
+						}
+						pages.set(i, UploadedPage.upload(clientWorld, preparedRail.pages.get(i)));
+						uploadedCount[0]++;
+					}
+				}
+				return true;
+			});
+			return uploaded == null ? 0 : uploadedCount[0];
+		}
+
+		private void invalidateBounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+			for (int i = 0; i < pages.size(); i++) {
+				final UploadedPage uploadedPage = pages.get(i);
+				if (uploadedPage != null && preparedRail.pages.get(i).intersects(minX, minY, minZ, maxX, maxY, maxZ)) {
+					uploadedPage.close();
+					pages.set(i, null);
+				}
+			}
+		}
+
+		@Override
+		public void close() {
+			for (final UploadedPage page : pages) {
+				if (page != null) {
+					page.close();
+				}
+			}
+		}
+	}
+
+	private DefaultRailMeshCache() {
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/render/MainRenderer.java
+++ b/fabric/src/main/java/org/mtr/mod/render/MainRenderer.java
@@ -82,8 +82,9 @@ public class MainRenderer extends EntityRenderer<EntityRendering> implements IGu
 			return;
 		}
 
+		final boolean renderingShadows = OptimizedRenderer.renderingShadows();
 		final long millisElapsed;
-		if (OptimizedRenderer.renderingShadows()) {
+		if (renderingShadows) {
 			if (Config.getClient().getDisableShadowsForShaders()) {
 				return;
 			}
@@ -111,7 +112,10 @@ public class MainRenderer extends EntityRenderer<EntityRendering> implements IGu
 		final Vector3d cameraShakeOffset = clientPlayerEntity.getPos().subtract(offset);
 		RenderVehicles.render(millisElapsed, cameraShakeOffset);
 		RenderLifts.render(millisElapsed, cameraShakeOffset);
+		DefaultRailMeshCache.beginFrame(clientWorld, renderingShadows);
 		RenderRails.render();
+		DefaultRailMeshCache.finishFrame(clientWorld);
+		DefaultRailMeshCache.scheduleRender();
 
 		for (int i = 0; i < TOTAL_RENDER_STAGES; i++) {
 			for (int j = 0; j < QueuedRenderLayer.values().length; j++) {

--- a/fabric/src/main/java/org/mtr/mod/render/RailVisibility.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RailVisibility.java
@@ -1,0 +1,29 @@
+package org.mtr.mod.render;
+
+final class RailVisibility {
+
+	private static final double NEAR_RENDER_DISTANCE = 32;
+	private static final double NEAR_RENDER_DISTANCE_SQUARED = NEAR_RENDER_DISTANCE * NEAR_RENDER_DISTANCE;
+
+	static boolean shouldRender(double x, double y, double z, double cameraX, double cameraY, double cameraZ, double renderDistance, double renderDistanceSquared, float yawCos, float yawSin, float pitchCos, float pitchSin) {
+		final double differenceX = x - cameraX;
+		final double differenceZ = z - cameraZ;
+		final double distanceSquared = differenceX * differenceX + differenceZ * differenceZ;
+		if (!compareSquaredDistance(distanceSquared, renderDistanceSquared, renderDistance, true)) {
+			return false;
+		}
+		if (compareSquaredDistance(distanceSquared, NEAR_RENDER_DISTANCE_SQUARED, NEAR_RENDER_DISTANCE, false)) {
+			return true;
+		}
+		final double yawRotatedZ = differenceZ * yawCos - differenceX * yawSin;
+		return yawRotatedZ * pitchCos - (y - cameraY) * pitchSin > 0;
+	}
+
+	private static boolean compareSquaredDistance(double distanceSquared, double thresholdSquared, double threshold, boolean inclusive) {
+		if (Math.abs(distanceSquared - thresholdSquared) <= Math.ulp(thresholdSquared) * 4) {
+			final double distance = Math.sqrt(distanceSquared);
+			return inclusive ? distance <= threshold : distance < threshold;
+		}
+		return inclusive ? distanceSquared <= thresholdSquared : distanceSquared < thresholdSquared;
+	}
+}

--- a/fabric/src/main/java/org/mtr/mod/render/RenderAPGGlass.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderAPGGlass.java
@@ -19,6 +19,15 @@ public class RenderAPGGlass extends RenderRouteBase<BlockAPGGlass.BlockEntity> {
 	}
 
 	@Override
+	protected boolean shouldRenderRoute(BlockState state) {
+		return getClass() != RenderAPGGlass.class || shouldRenderState(IBlock.getStatePropertySafe(state, HALF), IBlock.getStatePropertySafe(state, SIDE_EXTENDED));
+	}
+
+	static boolean shouldRenderState(DoubleBlockHalf half, EnumSide side) {
+		return half == DoubleBlockHalf.UPPER && side != EnumSide.SINGLE;
+	}
+
+	@Override
 	protected RenderType getRenderType(World world, BlockPos pos, BlockState state) {
 		if (IBlock.getStatePropertySafe(state, HALF) == DoubleBlockHalf.LOWER) {
 			return RenderType.NONE;

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRails.java
@@ -62,7 +62,7 @@ public class RenderRails implements IGui {
 			return;
 		}
 
-		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = new ObjectArrayList<>();
+		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = OptimizedRenderer.renderingShadows() ? null : new ObjectArrayList<>();
 		final Vector3d cameraPosition = minecraftClient.getGameRendererMapped().getCamera().getPos();
 		final Vec3d camera = new Vec3d(cameraPosition.getXMapped(), cameraPosition.getYMapped(), cameraPosition.getZMapped());
 		final boolean holdingRailRelated = isHoldingRailRelated(clientPlayerEntity);
@@ -70,10 +70,12 @@ public class RenderRails implements IGui {
 		// Finding visible rails
 		final ObjectArrayList<Rail> railsToRender = new ObjectArrayList<>();
 		MinecraftClientData.getInstance().railWrapperList.values().forEach(railWrapper -> {
-			cullingTasks.add(occlusionCullingInstance -> {
-				final boolean shouldRender = occlusionCullingInstance.isAABBVisible(railWrapper.startVector, railWrapper.endVector, camera);
-				return () -> railWrapper.shouldRender = shouldRender;
-			});
+			if (cullingTasks != null) {
+				cullingTasks.add(occlusionCullingInstance -> {
+					final boolean shouldRender = occlusionCullingInstance.isAABBVisible(railWrapper.startVector, railWrapper.endVector, camera);
+					return () -> railWrapper.shouldRender = shouldRender;
+				});
+			}
 			if (railWrapper.shouldRender) {
 				railsToRender.add(railWrapper.getRail());
 			}
@@ -203,7 +205,7 @@ public class RenderRails implements IGui {
 			}
 		}
 
-		if (!OptimizedRenderer.renderingShadows()) {
+		if (cullingTasks != null) {
 			MainRenderer.WORKER_THREAD.scheduleMTRRails(occlusionCullingInstance -> {
 				final ObjectArrayList<Runnable> tasks = new ObjectArrayList<>();
 				cullingTasks.forEach(occlusionCullingInstanceRunnableFunction -> tasks.add(occlusionCullingInstanceRunnableFunction.apply(occlusionCullingInstance)));
@@ -236,6 +238,9 @@ public class RenderRails implements IGui {
 	}
 
 	private static void renderRailStandard(ClientWorld clientWorld, Rail rail, RenderState renderState, float railWidth) {
+		if (DefaultRailMeshCache.tryRender(clientWorld, rail, renderState == RenderState.NORMAL, railWidth)) {
+			return;
+		}
 		renderRailStandard(clientWorld, rail, 0.065625F, renderState, railWidth, renderState.hasColor ? RAIL_PREVIEW_TEXTURE : RAIL_TEXTURE, -1, -1, -1, -1);
 	}
 
@@ -317,20 +322,21 @@ public class RenderRails implements IGui {
 	private static void renderWithinRenderDistance(Rail rail, RenderRailWithBlockPos callback, double interval, float offsetRadius1, float offsetRadius2) {
 		final Camera camera = MinecraftClient.getInstance().getGameRendererMapped().getCamera();
 		final Vector3d cameraPosition = camera.getPos();
-		final int renderDistance = MinecraftClientHelper.getRenderDistance() * 16;
+		final double cameraX = cameraPosition.getXMapped();
+		final double cameraY = cameraPosition.getYMapped();
+		final double cameraZ = cameraPosition.getZMapped();
+		final double renderDistance = MinecraftClientHelper.getRenderDistance() * 16;
+		final double renderDistanceSquared = renderDistance * renderDistance;
+		final float yaw = (float) Math.toRadians(camera.getYaw());
+		final float pitch = (float) Math.toRadians(camera.getPitch());
+		final float yawCos = MathHelper.cos(yaw);
+		final float yawSin = MathHelper.sin(yaw);
+		final float pitchCos = MathHelper.cos(pitch);
+		final float pitchSin = MathHelper.sin(pitch);
 
 		rail.railMath.render((x1, z1, x2, z2, x3, z3, x4, z4, y1, y2) -> {
-			final BlockPos blockPos = Init.newBlockPos(x1, y1 + LIGHT_REFERENCE_OFFSET, z1);
-			final double distanceToCamera = new Vector3d(x1, 0, z1).distanceTo(new Vector3d(cameraPosition.getXMapped(), 0, cameraPosition.getZMapped())); // Minecraft does not have vertical render distance, no need to compare the Y-axis.
-			if (distanceToCamera <= renderDistance) {
-				if (distanceToCamera < 32) {
-					callback.renderRail(blockPos, x1, z1, x2, z2, x3, z3, x4, z4, y1, y2);
-				} else {
-					final Vector3d rotatedVector = new Vector3d(x1, y1, z1).subtract(cameraPosition).rotateY((float) Math.toRadians(camera.getYaw())).rotateX((float) Math.toRadians(camera.getPitch()));
-					if (rotatedVector.getZMapped() > 0) {
-						callback.renderRail(blockPos, x1, z1, x2, z2, x3, z3, x4, z4, y1, y2);
-					}
-				}
+			if (RailVisibility.shouldRender(x1, y1, z1, cameraX, cameraY, cameraZ, renderDistance, renderDistanceSquared, yawCos, yawSin, pitchCos, pitchSin)) {
+				callback.renderRail(Init.newBlockPos(x1, y1 + LIGHT_REFERENCE_OFFSET, z1), x1, z1, x2, z2, x3, z3, x4, z4, y1, y2);
 			}
 		}, interval, offsetRadius1, offsetRadius2);
 	}

--- a/fabric/src/main/java/org/mtr/mod/render/RenderRouteBase.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderRouteBase.java
@@ -41,6 +41,9 @@ public abstract class RenderRouteBase<T extends BlockPSDTop.BlockEntityBase> ext
 
 		final BlockPos blockPos = entity.getPos2();
 		final BlockState state = world.getBlockState(blockPos);
+		if (!shouldRenderRoute(state)) {
+			return;
+		}
 		final Direction facing = IBlock.getStatePropertySafe(state, DirectionHelper.FACING);
 
 		final StoredMatrixTransformations storedMatrixTransformations = new StoredMatrixTransformations(0.5 + entity.getPos2().getX(), entity.getPos2().getY(), 0.5 + entity.getPos2().getZ());
@@ -57,8 +60,8 @@ public abstract class RenderRouteBase<T extends BlockPSDTop.BlockEntityBase> ext
 				graphicsHolderNew.translate(-0.5, -getAdditionalOffset(state), z);
 			});
 
-			final int leftBlocks = getTextureNumber(world, blockPos, facing, true);
-			final int rightBlocks = getTextureNumber(world, blockPos, facing, false);
+			final int leftBlocks = getTextureNumber(world, blockPos, state, facing, true);
+			final int rightBlocks = getTextureNumber(world, blockPos, state, facing, false);
 			final int color = getShadingColor(facing, ARGB_WHITE);
 			final RenderType renderType = getRenderType(world, blockPos.offset(facing.rotateYCounterclockwise(), leftBlocks), state);
 
@@ -97,6 +100,10 @@ public abstract class RenderRouteBase<T extends BlockPSDTop.BlockEntityBase> ext
 		return 0;
 	}
 
+	protected boolean shouldRenderRoute(BlockState state) {
+		return true;
+	}
+
 	protected boolean isLeft(BlockState state) {
 		return IBlock.getStatePropertySafe(state, SIDE_EXTENDED) == IBlock.EnumSide.LEFT;
 	}
@@ -109,18 +116,22 @@ public abstract class RenderRouteBase<T extends BlockPSDTop.BlockEntityBase> ext
 
 	protected abstract void renderAdditional(StoredMatrixTransformations storedMatrixTransformations, long platformId, BlockState state, int leftBlocks, int rightBlocks, Direction facing, int color, int light);
 
-	private int getTextureNumber(World world, BlockPos pos, Direction facing, boolean searchLeft) {
-		int number = 0;
-		final Block thisBlock = world.getBlockState(pos).getBlock();
+	private int getTextureNumber(World world, BlockPos pos, BlockState initialState, Direction facing, boolean searchLeft) {
+		if (searchLeft ? isLeft(initialState) : isRight(initialState)) {
+			return 0;
+		}
+		int number = 1;
+		final Block thisBlock = initialState.getBlock();
+		final Direction searchDirection = searchLeft ? facing.rotateYCounterclockwise() : facing.rotateYClockwise();
 
 		while (true) {
-			final BlockState state = world.getBlockState(pos.offset(searchLeft ? facing.rotateYCounterclockwise() : facing.rotateYClockwise(), number));
+			final BlockState state = world.getBlockState(pos.offset(searchDirection, number));
 
 			if (state.getBlock().equals(thisBlock)) {
 				final boolean isLeft = isLeft(state);
 				final boolean isRight = isRight(state);
 
-				if (number == 0 || (searchLeft ? !isRight : !isLeft)) {
+				if (searchLeft ? !isRight : !isLeft) {
 					number++;
 					if (searchLeft ? isLeft : isRight) {
 						break;

--- a/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
+++ b/fabric/src/main/java/org/mtr/mod/render/RenderVehicles.java
@@ -41,9 +41,14 @@ public class RenderVehicles implements IGui {
 			return;
 		}
 
-		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = new ObjectArrayList<>();
-		final Vector3d cameraPosition = minecraftClient.getGameRendererMapped().getCamera().getPos();
-		final Vec3d camera = new Vec3d(cameraPosition.getXMapped(), cameraPosition.getYMapped(), cameraPosition.getZMapped());
+		final ObjectArrayList<Function<OcclusionCullingInstance, Runnable>> cullingTasks = OptimizedRenderer.renderingShadows() ? null : new ObjectArrayList<>();
+		final Vec3d camera;
+		if (cullingTasks == null) {
+			camera = null;
+		} else {
+			final Vector3d cameraPosition = minecraftClient.getGameRendererMapped().getCamera().getPos();
+			camera = new Vec3d(cameraPosition.getXMapped(), cameraPosition.getYMapped(), cameraPosition.getZMapped());
+		}
 
 		// When riding a moving vehicle, the client movement is always out of sync with the vehicle rendering. This produces annoying shaking effects.
 		// Offsets are used to render the vehicle with respect to the player position rather than the absolute world position, eliminating shaking.
@@ -58,16 +63,10 @@ public class RenderVehicles implements IGui {
 			final PreviousGangwayMovementPositions previousGangwayMovementPositions = new PreviousGangwayMovementPositions();
 
 			// Calculating vehicle transformations in advance
-			final ObjectArrayList<ObjectObjectImmutablePair<VehicleCar, ObjectObjectImmutablePair<ObjectArrayList<PositionAndRotation>, PositionAndRotation>>> vehiclePropertiesList = vehicle.getSmoothedVehicleCarsAndPositions(millisElapsed)
-					.stream()
-					.map(vehicleCarAndPosition -> {
-						final ObjectArrayList<PositionAndRotation> bogiePositions = vehicleCarAndPosition.right()
-								.stream()
-								.map(bogiePositionPair -> new PositionAndRotation(bogiePositionPair.left(), bogiePositionPair.right(), true))
-								.collect(Collectors.toCollection(ObjectArrayList::new));
-						return new ObjectObjectImmutablePair<>(vehicleCarAndPosition.left(), new ObjectObjectImmutablePair<>(bogiePositions, new PositionAndRotation(bogiePositions, vehicleCarAndPosition.left(), vehicle.getTransportMode().hasPitchAscending || vehicle.getTransportMode().hasPitchDescending)));
-					})
-					.collect(Collectors.toCollection(ObjectArrayList::new));
+			final ObjectArrayList<ObjectObjectImmutablePair<VehicleCar, ObjectObjectImmutablePair<ObjectArrayList<PositionAndRotation>, PositionAndRotation>>> vehiclePropertiesList = vehicle.getSmoothedVehicleCarsAndPositions(millisElapsed).stream().map(vehicleCarAndPosition -> {
+				final ObjectArrayList<PositionAndRotation> bogiePositions = vehicleCarAndPosition.right().stream().map(bogiePositionPair -> new PositionAndRotation(bogiePositionPair.left(), bogiePositionPair.right(), true)).collect(Collectors.toCollection(ObjectArrayList::new));
+				return new ObjectObjectImmutablePair<>(vehicleCarAndPosition.left(), new ObjectObjectImmutablePair<>(bogiePositions, new PositionAndRotation(bogiePositions, vehicleCarAndPosition.left(), vehicle.getTransportMode().hasPitchAscending || vehicle.getTransportMode().hasPitchDescending)));
+			}).collect(Collectors.toCollection(ObjectArrayList::new));
 
 			// Riding offset
 			final IntObjectImmutablePair<ObjectObjectImmutablePair<Vector3d, Double>> ridingVehicleCarNumberAndOffset = VehicleRidingMovement.getRidingVehicleCarNumberAndOffset(vehicle.getId());
@@ -90,19 +89,21 @@ public class RenderVehicles implements IGui {
 
 			// Iterate all cars of a vehicle
 			iterateWithIndex(vehiclePropertiesList, (carNumber, vehicleCarDetails) -> {
-				cullingTasks.add(occlusionCullingInstance -> {
-					final double longestDimension = vehicle.persistentVehicleData.longestDimensions[carNumber];
-					final boolean shouldRender = occlusionCullingInstance.isAABBVisible(new Vec3d(
-							vehicleCarDetails.right().right().position.x - longestDimension,
-							vehicleCarDetails.right().right().position.y - 8,
-							vehicleCarDetails.right().right().position.z - longestDimension
-					), new Vec3d(
-							vehicleCarDetails.right().right().position.x + longestDimension,
-							vehicleCarDetails.right().right().position.y + 8,
-							vehicleCarDetails.right().right().position.z + longestDimension
-					), camera);
-					return () -> vehicle.persistentVehicleData.rayTracing[carNumber] = shouldRender;
-				});
+				if (cullingTasks != null) {
+					cullingTasks.add(occlusionCullingInstance -> {
+						final double longestDimension = vehicle.persistentVehicleData.longestDimensions[carNumber];
+						final boolean shouldRender = occlusionCullingInstance.isAABBVisible(new Vec3d(
+								vehicleCarDetails.right().right().position.x - longestDimension,
+								vehicleCarDetails.right().right().position.y - 8,
+								vehicleCarDetails.right().right().position.z - longestDimension
+						), new Vec3d(
+								vehicleCarDetails.right().right().position.x + longestDimension,
+								vehicleCarDetails.right().right().position.y + 8,
+								vehicleCarDetails.right().right().position.z + longestDimension
+						), camera);
+						return () -> vehicle.persistentVehicleData.rayTracing[carNumber] = shouldRender;
+					});
+				}
 
 				if (vehicle.persistentVehicleData.rayTracing[carNumber] || VehicleRidingMovement.isRiding(vehicle.getId())) {
 					CustomResourceLoader.getVehicleById(vehicle.getTransportMode(), vehicleCarDetails.left().getVehicleId(), vehicleResourceDetails -> {
@@ -345,7 +346,7 @@ public class RenderVehicles implements IGui {
 			});
 		});
 
-		if (!OptimizedRenderer.renderingShadows()) {
+		if (cullingTasks != null) {
 			MainRenderer.WORKER_THREAD.scheduleVehicles(occlusionCullingInstance -> {
 				final ObjectArrayList<Runnable> tasks = new ObjectArrayList<>();
 				cullingTasks.forEach(occlusionCullingInstanceRunnableFunction -> tasks.add(occlusionCullingInstanceRunnableFunction.apply(occlusionCullingInstance)));

--- a/fabric/src/main/java/org/mtr/mod/resource/OptimizedRendererWrapper.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/OptimizedRendererWrapper.java
@@ -1,15 +1,20 @@
 package org.mtr.mod.resource;
 
 import org.mtr.mapping.mapper.GraphicsHolder;
+import org.mtr.mapping.mapper.OptimizedModel;
 import org.mtr.mapping.mapper.OptimizedRenderer;
+import org.mtr.mapping.render.tool.GlStateTracker;
 import org.mtr.mod.data.IGui;
 
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 public final class OptimizedRendererWrapper implements IGui {
 
 	@Nullable
 	private final OptimizedRenderer optimizedRenderer;
+	private boolean shadersReady;
+	private int reloadDepth;
 
 	public OptimizedRendererWrapper() {
 		this.optimizedRenderer = OptimizedRenderer.hasOptimizedRendering() ? new OptimizedRenderer() : null;
@@ -17,13 +22,20 @@ public final class OptimizedRendererWrapper implements IGui {
 
 	public void beginReload() {
 		if (optimizedRenderer != null) {
-			optimizedRenderer.beginReload();
+			if (reloadDepth == 0) {
+				optimizedRenderer.beginReload();
+				shadersReady = true;
+			}
+			reloadDepth++;
 		}
 	}
 
 	public void finishReload() {
-		if (optimizedRenderer != null) {
-			optimizedRenderer.finishReload();
+		if (optimizedRenderer != null && reloadDepth > 0) {
+			reloadDepth--;
+			if (reloadDepth == 0) {
+				optimizedRenderer.finishReload();
+			}
 		}
 	}
 
@@ -31,6 +43,41 @@ public final class OptimizedRendererWrapper implements IGui {
 		if (optimizedRenderer != null && optimizedModel.optimizedModel != null) {
 			optimizedRenderer.queue(optimizedModel.optimizedModel, graphicsHolder, ARGB_WHITE, light);
 		}
+	}
+
+	public void queue(OptimizedModel optimizedModel, GraphicsHolder graphicsHolder, int color, int light) {
+		if (optimizedRenderer != null && optimizedModel != null) {
+			optimizedRenderer.queue(optimizedModel, graphicsHolder, color, light);
+		}
+	}
+
+	@Nullable
+	public <T> T upload(Supplier<T> uploader) {
+		if (optimizedRenderer == null) {
+			return null;
+		}
+		if (reloadDepth > 0) {
+			return uploader.get();
+		}
+		final boolean initializeShaders = !shadersReady;
+		if (initializeShaders) {
+			beginReload();
+		} else {
+			GlStateTracker.capture();
+		}
+		try {
+			return uploader.get();
+		} finally {
+			if (initializeShaders) {
+				finishReload();
+			} else {
+				GlStateTracker.restore();
+			}
+		}
+	}
+
+	public void markReloadRequired() {
+		shadersReady = false;
 	}
 
 	public void render(boolean renderTranslucent) {

--- a/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/StoredModelResourceBase.java
@@ -19,47 +19,48 @@ public interface StoredModelResourceBase {
 
 	default ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> load(String modelResource, String textureResource, boolean flipTextureV, double modelYOffset, ResourceProvider resourceProvider) {
 		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
+		try {
+			final boolean isBlockbench = modelResource.endsWith(".bbmodel");
+			final boolean isSupportedModelResource = ModelResourceLoader.isSupportedModelResource(modelResource);
+			final Identifier textureId = CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
+			ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> models;
 
-		final boolean isBlockbench = modelResource.endsWith(".bbmodel");
-		final boolean isSupportedModelResource = ModelResourceLoader.isSupportedModelResource(modelResource);
-		final Identifier textureId = CustomResourceTools.formatIdentifierWithDefault(textureResource, "png");
-		ObjectObjectImmutablePair<OptimizedModelWrapper, DynamicVehicleModel> models;
-
-		if (isBlockbench) {
-			final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroups = new Object2ObjectOpenHashMap<>();
-			final DynamicVehicleModel tempDynamicVehicleModel = new DynamicVehicleModel(
-					new BlockbenchModel(new JsonReader(Utilities.parseJson(resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "bbmodel"))))),
-					textureId,
-					new ModelProperties(modelYOffset),
-					new PositionDefinitions(),
-					""
-			);
-			tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
-			models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromMaterialGroups(materialGroups.get(PartCondition.NORMAL)), tempDynamicVehicleModel);
-		} else if (isSupportedModelResource) {
-			try {
-				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModels = new Object2ObjectOpenHashMap<>();
-				final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = ModelResourceLoader.loadModel(modelResource, textureId, flipTextureV, resourceProvider);
-				transform(rawModels.values());
-				final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
-						rawModels,
+			if (isBlockbench) {
+				final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper>> materialGroups = new Object2ObjectOpenHashMap<>();
+				final DynamicVehicleModel tempDynamicVehicleModel = new DynamicVehicleModel(
+						new BlockbenchModel(new JsonReader(Utilities.parseJson(resourceProvider.get(CustomResourceTools.formatIdentifierWithDefault(modelResource, "bbmodel"))))),
 						textureId,
 						new ModelProperties(modelYOffset),
 						new PositionDefinitions(),
 						""
 				);
-				dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
-				models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
-			} catch (Exception e) {
-				Init.LOGGER.error("[{}] Invalid model!", modelResource, e);
+				tempDynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), materialGroups, new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>());
+				models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromMaterialGroups(materialGroups.get(PartCondition.NORMAL)), tempDynamicVehicleModel);
+			} else if (isSupportedModelResource) {
+				try {
+					final Object2ObjectOpenHashMap<PartCondition, ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper>> objModels = new Object2ObjectOpenHashMap<>();
+					final Object2ObjectAVLTreeMap<String, OptimizedModel.ObjModel> rawModels = ModelResourceLoader.loadModel(modelResource, textureId, flipTextureV, resourceProvider);
+					transform(rawModels.values());
+					final DynamicVehicleModel dynamicVehicleModel = new DynamicVehicleModel(
+							rawModels,
+							textureId,
+							new ModelProperties(modelYOffset),
+							new PositionDefinitions(),
+							""
+					);
+					dynamicVehicleModel.writeFloorsAndDoorways(new ObjectArrayList<>(), new ObjectArrayList<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), new Object2ObjectOpenHashMap<>(), objModels);
+					models = new ObjectObjectImmutablePair<>(OptimizedModelWrapper.fromObjModels(objModels.get(PartCondition.NORMAL)), dynamicVehicleModel);
+				} catch (Exception e) {
+					Init.LOGGER.error("[{}] Invalid model!", modelResource, e);
+					models = new ObjectObjectImmutablePair<>(null, null);
+				}
+			} else {
 				models = new ObjectObjectImmutablePair<>(null, null);
 			}
-		} else {
-			models = new ObjectObjectImmutablePair<>(null, null);
+			return models;
+		} finally {
+			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 		}
-
-		CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
-		return models;
 	}
 
 	default void render(StoredMatrixTransformations storedMatrixTransformations, int light) {

--- a/fabric/src/main/java/org/mtr/mod/resource/VehicleResource.java
+++ b/fabric/src/main/java/org/mtr/mod/resource/VehicleResource.java
@@ -534,21 +534,24 @@ public final class VehicleResource extends VehicleResourceSchema {
 	) {
 		return new CachedResource<>(() -> {
 			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.beginReload();
-			final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModels = new Object2ObjectOpenHashMap<>();
+			try {
+				final Object2ObjectOpenHashMap<PartCondition, OptimizedModelWrapper> optimizedModels = new Object2ObjectOpenHashMap<>();
 
-			for (final PartCondition partCondition : PartCondition.values()) {
-				final OptimizedModelWrapper optimizedModel1;
-				final ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper> materialGroups = materialGroupsModel.get(partCondition);
-				optimizedModel1 = materialGroups == null ? null : OptimizedModelWrapper.fromMaterialGroups(materialGroups);
+				for (final PartCondition partCondition : PartCondition.values()) {
+					final OptimizedModelWrapper optimizedModel1;
+					final ObjectArrayList<OptimizedModelWrapper.MaterialGroupWrapper> materialGroups = materialGroupsModel.get(partCondition);
+					optimizedModel1 = materialGroups == null ? null : OptimizedModelWrapper.fromMaterialGroups(materialGroups);
 
-				final OptimizedModelWrapper optimizedModel2;
-				final ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper> objModels = objModelsModel.get(partCondition);
-				optimizedModel2 = objModels == null ? null : OptimizedModelWrapper.fromObjModels(objModels);
-				optimizedModels.put(partCondition, new OptimizedModelWrapper(optimizedModel1, optimizedModel2));
+					final OptimizedModelWrapper optimizedModel2;
+					final ObjectArrayList<OptimizedModelWrapper.ObjModelWrapper> objModels = objModelsModel.get(partCondition);
+					optimizedModel2 = objModels == null ? null : OptimizedModelWrapper.fromObjModels(objModels);
+					optimizedModels.put(partCondition, new OptimizedModelWrapper(optimizedModel1, optimizedModel2));
+				}
+
+				return optimizedModels;
+			} finally {
+				CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
 			}
-
-			CustomResourceLoader.OPTIMIZED_RENDERER_WRAPPER.finishReload();
-			return optimizedModels;
 		}, modelLifespan);
 	}
 

--- a/fabric/src/main/resources/mtr.mixins.json
+++ b/fabric/src/main/resources/mtr.mixins.json
@@ -8,6 +8,7 @@
 		"PlayerTeleportationStateAccessor"
 	],
 	"client": [
+		"ClientChunkLightUpdateMixin",
 		"ClientWorldRenderingMixin",
 		"PlayerRendererOffsetMixin"
 	],

--- a/fabric/src/test/java/org/mtr/mod/client/DynamicTextureGenerationTrackerTest.java
+++ b/fabric/src/test/java/org/mtr/mod/client/DynamicTextureGenerationTrackerTest.java
@@ -1,0 +1,61 @@
+package org.mtr.mod.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class DynamicTextureGenerationTrackerTest {
+
+	@Test
+	public void testCurrentGenerationLifecycle() {
+		final DynamicTextureGenerationTracker tracker = new DynamicTextureGenerationTracker();
+		final DynamicTextureGenerationTracker.Token token = tracker.start("key");
+
+		Assertions.assertTrue(tracker.isActive("key"));
+		Assertions.assertTrue(tracker.isCurrent("key", token));
+
+		tracker.completeSuccess("key", token);
+
+		Assertions.assertFalse(tracker.isActive("key"));
+		Assertions.assertFalse(tracker.isRetryBlocked("key", 100));
+	}
+
+	@Test
+	public void testRefreshSupersedesQueuedCompletion() {
+		final DynamicTextureGenerationTracker tracker = new DynamicTextureGenerationTracker();
+		final DynamicTextureGenerationTracker.Token staleToken = tracker.start("key");
+		tracker.refresh();
+		final DynamicTextureGenerationTracker.Token currentToken = tracker.start("key");
+
+		tracker.completeFailure("key", staleToken, 200);
+
+		Assertions.assertTrue(tracker.isCurrent("key", currentToken));
+		Assertions.assertFalse(tracker.isRetryBlocked("key", 100));
+
+		tracker.completeSuccess("key", staleToken);
+
+		Assertions.assertTrue(tracker.isCurrent("key", currentToken));
+	}
+
+	@Test
+	public void testFailureBackoffExpires() {
+		final DynamicTextureGenerationTracker tracker = new DynamicTextureGenerationTracker();
+		final DynamicTextureGenerationTracker.Token token = tracker.start("key");
+		tracker.completeFailure("key", token, 200);
+
+		Assertions.assertFalse(tracker.isActive("key"));
+		Assertions.assertTrue(tracker.isRetryBlocked("key", 199));
+		Assertions.assertFalse(tracker.isRetryBlocked("key", 200));
+		Assertions.assertFalse(tracker.isRetryBlocked("key", 201));
+	}
+
+	@Test
+	public void testRefreshClearsFailureBackoff() {
+		final DynamicTextureGenerationTracker tracker = new DynamicTextureGenerationTracker();
+		final DynamicTextureGenerationTracker.Token token = tracker.start("key");
+		tracker.completeFailure("key", token, Long.MAX_VALUE);
+
+		tracker.refresh();
+
+		Assertions.assertFalse(tracker.isRetryBlocked("key", 0));
+	}
+}

--- a/fabric/src/test/java/org/mtr/mod/render/DefaultRailMeshCacheTest.java
+++ b/fabric/src/test/java/org/mtr/mod/render/DefaultRailMeshCacheTest.java
@@ -1,0 +1,557 @@
+package org.mtr.mod.render;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mtr.core.data.Rail;
+import org.mtr.core.data.TransportMode;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.mapping.holder.ClientWorld;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.render.model.Mesh;
+import org.mtr.mapping.render.vertex.Vertex;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeSource;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+import org.mtr.mod.data.IGui;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+public final class DefaultRailMeshCacheTest {
+
+	private static final String CACHE_CLASS_NAME = "org.mtr.mod.render.DefaultRailMeshCache";
+
+	@Test
+	public void onlyNormalTrainDefaultTwoDimensionalRailsAreEligible() {
+		final Method isEligible = requirePackageApi(
+				"isEligible",
+				boolean.class,
+				TransportMode.class,
+				Iterable.class,
+				boolean.class
+		);
+
+		Assertions.assertTrue(invokeBoolean(isEligible, true, TransportMode.TRAIN, Collections.singletonList("default"), false));
+		Assertions.assertFalse(invokeBoolean(isEligible, false, TransportMode.TRAIN, Collections.singletonList("default"), false), "coloured or flashing rails must stay on the dynamic path");
+		Assertions.assertFalse(invokeBoolean(isEligible, true, TransportMode.BOAT, Collections.singletonList("default"), false), "only TRAIN rails use the cached default geometry");
+		Assertions.assertFalse(invokeBoolean(isEligible, true, TransportMode.TRAIN, Collections.singletonList("custom"), false), "custom-only styles need their resource renderers");
+		Assertions.assertFalse(invokeBoolean(isEligible, true, TransportMode.TRAIN, Arrays.asList("default", "custom"), false), "mixed styles must preserve custom resource rendering");
+		Assertions.assertFalse(invokeBoolean(isEligible, true, TransportMode.TRAIN, Collections.singletonList("default"), true), "defaultRail3D replaces the two-dimensional default rail");
+	}
+
+	@Test
+	public void cellBatchingRetainsVoxelOcclusionSelection() throws Exception {
+		Path renderRailsPath = Path.of("src", "main", "java", "org", "mtr", "mod", "render", "RenderRails.java");
+		if (!Files.exists(renderRailsPath)) {
+			renderRailsPath = Path.of("fabric").resolve(renderRailsPath);
+		}
+		Assertions.assertTrue(Files.exists(renderRailsPath), "RenderRails source must be available for culling integration verification");
+		final String renderRailsSource = Files.readString(renderRailsPath);
+		Assertions.assertFalse(renderRailsSource.contains("shouldBypassOcclusionCulling"), "cached rails must continue through JCM culling");
+		Assertions.assertTrue(renderRailsSource.contains("cullingTasks.add(occlusionCullingInstance ->"), "the JCM culling lambda must remain present");
+		Assertions.assertTrue(renderRailsSource.contains("if (cullingTasks != null)"), "the original JCM culling batch scheduling guard must remain present");
+	}
+
+	@Test
+	public void splitsSixtyFourMeterPagesAtOneHundredTwentyEightHalfMeterSegments() {
+		Assertions.assertEquals(64D, requireNumericConstant("PAGE_LENGTH_METERS").doubleValue());
+		Assertions.assertEquals(128, requireNumericConstant("SEGMENTS_PER_PAGE").intValue());
+
+		final Method pageIndexForSegment = requirePackageApi("pageIndexForSegment", int.class);
+		Assertions.assertEquals(0, invokeInt(pageIndexForSegment, 0));
+		Assertions.assertEquals(0, invokeInt(pageIndexForSegment, 127));
+		Assertions.assertEquals(1, invokeInt(pageIndexForSegment, 128));
+		Assertions.assertEquals(1, invokeInt(pageIndexForSegment, 255));
+		Assertions.assertEquals(2, invokeInt(pageIndexForSegment, 256));
+
+		final Method pageCountForSegments = requirePackageApi("pageCountForSegments", int.class);
+		Assertions.assertEquals(0, invokeInt(pageCountForSegments, 0));
+		Assertions.assertEquals(1, invokeInt(pageCountForSegments, 1));
+		Assertions.assertEquals(1, invokeInt(pageCountForSegments, 128));
+		Assertions.assertEquals(2, invokeInt(pageCountForSegments, 129));
+		Assertions.assertEquals(2, invokeInt(pageCountForSegments, 256));
+		Assertions.assertEquals(3, invokeInt(pageCountForSegments, 257));
+	}
+
+	@Test
+	public void geometryFingerprintChangesWithEveryGeometryInput() {
+		final Method geometryFingerprint = requirePackageApi(
+				"geometryFingerprint",
+				double.class,
+				double.class,
+				Rail.Shape.class,
+				double.class,
+				double.class
+		);
+		final long baseline = invokeLong(geometryFingerprint, 0D, 0D, Rail.Shape.QUADRATIC, 0D, 128D);
+
+		Assertions.assertNotEquals(baseline, invokeLong(geometryFingerprint, 0.5D, 0D, Rail.Shape.QUADRATIC, 0D, 128D), "start angle must invalidate cached geometry");
+		Assertions.assertNotEquals(baseline, invokeLong(geometryFingerprint, 0D, 0.5D, Rail.Shape.QUADRATIC, 0D, 128D), "end angle must invalidate cached geometry");
+		Assertions.assertNotEquals(baseline, invokeLong(geometryFingerprint, 0D, 0D, Rail.Shape.TWO_RADII, 0D, 128D), "shape must invalidate cached geometry");
+		Assertions.assertNotEquals(baseline, invokeLong(geometryFingerprint, 0D, 0D, Rail.Shape.QUADRATIC, 64D, 128D), "vertical radius must invalidate cached geometry");
+		Assertions.assertNotEquals(baseline, invokeLong(geometryFingerprint, 0D, 0D, Rail.Shape.QUADRATIC, 0D, 129D), "length must invalidate cached geometry");
+	}
+
+	@Test
+	public void cachedVertexLayoutKeepsPerVertexLightmap() {
+		final VertexAttributeMapping mapping = (VertexAttributeMapping) requireStaticField("RAIL_MAPPING");
+		Assertions.assertEquals(28, mapping.strideVertex);
+		Assertions.assertEquals(VertexAttributeSource.VERTEX_BUFFER, mapping.sources.get(VertexAttributeType.POSITION));
+		Assertions.assertEquals(VertexAttributeSource.GLOBAL, mapping.sources.get(VertexAttributeType.COLOR));
+		Assertions.assertEquals(VertexAttributeSource.VERTEX_BUFFER, mapping.sources.get(VertexAttributeType.UV_TEXTURE));
+		Assertions.assertEquals(VertexAttributeSource.GLOBAL, mapping.sources.get(VertexAttributeType.UV_OVERLAY));
+		Assertions.assertEquals(VertexAttributeSource.VERTEX_BUFFER, mapping.sources.get(VertexAttributeType.UV_LIGHTMAP));
+		Assertions.assertEquals(VertexAttributeSource.VERTEX_BUFFER, mapping.sources.get(VertexAttributeType.NORMAL));
+		Assertions.assertEquals(VertexAttributeSource.GLOBAL, mapping.sources.get(VertexAttributeType.MATRIX_MODEL));
+	}
+
+	@Test
+	public void writesLegacyDoubleSidedNonDegenerateRailQuadWithSignedTextureOffsets() {
+		final Method appendSegmentVertices = requirePackageApi(
+				"appendSegmentVertices",
+				Consumer.class,
+				double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class,
+				float.class, int.class
+		);
+		final List<Vertex> vertices = new ArrayList<>();
+		final int light = 0x00F000A0;
+
+		// x1 + z1 = 301, so the legacy texture offset is +0.25.
+		invoke(
+				appendSegmentVertices,
+				(Consumer<Vertex>) vertices::add,
+				100D, 60D, 200D,
+				101D, 200D, 103D, 200D,
+				103D, 204D, 101D, 204D,
+				61D, 62D,
+				0.065625F, light
+		);
+		assertNonDegenerateDoubleSidedQuad(vertices, 0.4375F, 0.5625F, light);
+
+		vertices.clear();
+		// x1 + z1 = -301, so Java's signed remainder gives a -0.25 offset.
+		invoke(
+				appendSegmentVertices,
+				(Consumer<Vertex>) vertices::add,
+				-102D, 60D, -200D,
+				-101D, -200D, -99D, -200D,
+				-99D, -196D, -101D, -196D,
+				61D, 62D,
+				0.065625F, light
+		);
+		assertNonDegenerateDoubleSidedQuad(vertices, -0.0625F, 0.0625F, light);
+	}
+
+	@Test
+	public void keepsPageLocalFloatPrecisionNearBothWorldBorders() {
+		final Method appendSegmentVertices = requirePackageApi(
+				"appendSegmentVertices",
+				Consumer.class,
+				double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class,
+				float.class, int.class
+		);
+
+		assertPageLocalPrecision(appendSegmentVertices, 29_999_960D);
+		assertPageLocalPrecision(appendSegmentVertices, -29_999_960D);
+	}
+
+	@Test
+	public void preparedPageBoundsCoverLightBlockAcrossSectionBoundary() throws ReflectiveOperationException {
+		final Class<?> builderClass = Arrays.stream(requireCacheClass().getDeclaredClasses())
+				.filter(candidate -> candidate.getSimpleName().equals("PreparedPageBuilder"))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Missing PreparedPageBuilder"));
+		final java.lang.reflect.Constructor<?> constructor = builderClass.getDeclaredConstructor(double.class, double.class, double.class);
+		constructor.setAccessible(true);
+		final Object builder = constructor.newInstance(2.25D, 15.92D, -3.75D);
+		final Method addSegment = builderClass.getDeclaredMethod(
+				"addSegment",
+				double.class, double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class
+		);
+		addSegment.setAccessible(true);
+
+		final double x1 = 2.25D;
+		final double y1 = 15.92D;
+		final double z1 = -3.75D;
+		addSegment.invoke(builder, x1, z1, 3.25D, z1, 3.25D, -2.75D, x1, -2.75D, y1, y1);
+
+		final int lightBlockX = (int) Math.floor(x1);
+		final int lightBlockY = (int) Math.floor(y1 + requireNumericConstant("LIGHT_REFERENCE_OFFSET").doubleValue());
+		final int lightBlockZ = (int) Math.floor(z1);
+		final double minX = requireDoubleField(builder, "minX");
+		final double minY = requireDoubleField(builder, "minY");
+		final double minZ = requireDoubleField(builder, "minZ");
+		final double maxX = requireDoubleField(builder, "maxX");
+		final double maxY = requireDoubleField(builder, "maxY");
+		final double maxZ = requireDoubleField(builder, "maxZ");
+
+		Assertions.assertEquals(16, lightBlockY, "the regression fixture must cross the Y section boundary");
+		Assertions.assertAll(
+				() -> Assertions.assertTrue(minX <= lightBlockX && maxX >= lightBlockX + 1, "bounds must cover the sampled light block on X"),
+				() -> Assertions.assertTrue(minY <= lightBlockY && maxY >= lightBlockY + 1, "bounds must cover the sampled light block on Y"),
+				() -> Assertions.assertTrue(minZ <= lightBlockZ && maxZ >= lightBlockZ + 1, "bounds must cover the sampled light block on Z")
+		);
+
+		final int sectionX = Math.floorDiv(lightBlockX, 16);
+		final int sectionY = Math.floorDiv(lightBlockY, 16);
+		final int sectionZ = Math.floorDiv(lightBlockZ, 16);
+		Assertions.assertTrue(
+				intersects(
+						minX, minY, minZ, maxX, maxY, maxZ,
+						sectionX * 16D, sectionY * 16D, sectionZ * 16D,
+						(sectionX + 1) * 16D, (sectionY + 1) * 16D, (sectionZ + 1) * 16D
+				),
+				"a light update for the sampled section must intersect the prepared page bounds"
+		);
+	}
+
+	@Test
+	public void pageVisibilityIsConservativeAtDistanceAndCameraPlaneBoundaries() {
+		final Method isPageVisible = requirePackageApi(
+				"isPageVisible",
+				double.class, double.class, double.class,
+				double.class, double.class, double.class,
+				double.class, double.class, double.class,
+				double.class,
+				float.class, float.class, float.class, float.class
+		);
+
+		Assertions.assertTrue(invokeBoolean(isPageVisible, -1D, -1D, -16D, 1D, 1D, -8D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "near pages stay visible even behind the camera");
+		Assertions.assertTrue(invokeBoolean(isPageVisible, -1D, -1D, 63D, 1D, 1D, 65D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "pages in front of the camera render");
+		Assertions.assertFalse(invokeBoolean(isPageVisible, -1D, -1D, -65D, 1D, 1D, -63D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "pages wholly behind the camera are culled outside the near radius");
+		Assertions.assertTrue(invokeBoolean(isPageVisible, 63D, -1D, -1D, 65D, 1D, 1D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "a page crossing the camera plane must not be falsely culled");
+		Assertions.assertFalse(invokeBoolean(isPageVisible, 225D, -1D, 0D, 230D, 1D, 5D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "pages beyond render distance are culled");
+		Assertions.assertTrue(invokeBoolean(isPageVisible, 223D, -1D, 0D, 225D, 1D, 5D, 0D, 0D, 0D, 224D, 1F, 0F, 1F, 0F), "pages touching render distance stay visible");
+	}
+
+	@Test
+	public void proactivePrewarmHooksRunAfterRailDiscoveryAndRetainTheRail() throws Exception {
+		final Method finishFrame = requireCacheClass().getDeclaredMethod("finishFrame", ClientWorld.class);
+		Assertions.assertAll(
+				() -> Assertions.assertTrue(Modifier.isPublic(finishFrame.getModifiers()), "finishFrame must be callable from MainRenderer"),
+				() -> Assertions.assertTrue(Modifier.isStatic(finishFrame.getModifiers()), "finishFrame must be static"),
+				() -> Assertions.assertEquals(void.class, finishFrame.getReturnType())
+		);
+
+		Path mainRendererPath = Path.of("src", "main", "java", "org", "mtr", "mod", "render", "MainRenderer.java");
+		if (!Files.exists(mainRendererPath)) {
+			mainRendererPath = Path.of("fabric").resolve(mainRendererPath);
+		}
+		Assertions.assertTrue(Files.exists(mainRendererPath), "MainRenderer source must be available for hook verification");
+		final String mainRendererSource = Files.readString(mainRendererPath);
+		final int beginFrameIndex = mainRendererSource.indexOf("DefaultRailMeshCache.beginFrame(clientWorld, renderingShadows);");
+		final int renderRailsIndex = mainRendererSource.indexOf("RenderRails.render();", beginFrameIndex);
+		final int finishFrameIndex = mainRendererSource.indexOf("DefaultRailMeshCache.finishFrame(clientWorld);", renderRailsIndex);
+		final int scheduleRenderIndex = mainRendererSource.indexOf("DefaultRailMeshCache.scheduleRender();", finishFrameIndex);
+		Assertions.assertTrue(
+				beginFrameIndex >= 0 && renderRailsIndex > beginFrameIndex && finishFrameIndex > renderRailsIndex && scheduleRenderIndex > finishFrameIndex,
+				"MainRenderer must run beginFrame -> rail discovery -> background finishFrame upload -> scheduleRender"
+		);
+
+		final Class<?> preparingEntryClass = requireNestedClass("PreparingEntry");
+		final Field railField = preparingEntryClass.getDeclaredField("rail");
+		Assertions.assertAll(
+				() -> Assertions.assertEquals(Rail.class, railField.getType(), "PreparingEntry must retain the Rail used by proactive preparation"),
+				() -> Assertions.assertTrue(Modifier.isFinal(railField.getModifiers()), "the prepared Rail identity must not change while its future is running"),
+				() -> Assertions.assertNotNull(preparingEntryClass.getDeclaredConstructor(Rail.class, long.class, Future.class), "PreparingEntry constructor must capture Rail, fingerprint, and future")
+		);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void missingPageStateSeparatesVisibleBlockingFromBackgroundPrewarm() throws ReflectiveOperationException {
+		setStaticDouble("cameraX", 0);
+		setStaticDouble("cameraY", 0);
+		setStaticDouble("cameraZ", 0);
+		setStaticDouble("renderDistance", 224);
+		setStaticFloat("yawCos", 1);
+		setStaticFloat("yawSin", 0);
+		setStaticFloat("pitchCos", 1);
+		setStaticFloat("pitchSin", 0);
+
+		final Class<?> preparedPageClass = requireNestedClass("PreparedPage");
+		final Class<?> preparedRailClass = requireNestedClass("PreparedRail");
+		final Class<?> cacheEntryClass = requireNestedClass("CacheEntry");
+		final Class<?> uploadedPageClass = requireNestedClass("UploadedPage");
+		final java.lang.reflect.Constructor<?> preparedPageConstructor = preparedPageClass.getDeclaredConstructor(
+				double.class, double.class, double.class,
+				double.class, double.class, double.class,
+				double.class, double.class, double.class,
+				double[].class, int.class, long.class
+		);
+		preparedPageConstructor.setAccessible(true);
+		final Object visiblePage = preparedPageConstructor.newInstance(0D, 0D, 64D, -1D, -1D, 63D, 1D, 1D, 65D, new double[0], 0, 0L);
+		final Object offscreenPage = preparedPageConstructor.newInstance(0D, 0D, -64D, -1D, -1D, -65D, 1D, 1D, -63D, new double[0], 0, 0L);
+
+		final java.lang.reflect.Constructor<?> preparedRailConstructor = preparedRailClass.getDeclaredConstructor(ObjectArrayList.class, long.class);
+		preparedRailConstructor.setAccessible(true);
+		final ObjectArrayList<Object> visiblePreparedPages = new ObjectArrayList<>();
+		visiblePreparedPages.add(visiblePage);
+		final ObjectArrayList<Object> offscreenPreparedPages = new ObjectArrayList<>();
+		offscreenPreparedPages.add(offscreenPage);
+		final Object visiblePreparedRail = preparedRailConstructor.newInstance(visiblePreparedPages, 0L);
+		final Object offscreenPreparedRail = preparedRailConstructor.newInstance(offscreenPreparedPages, 0L);
+
+		final java.lang.reflect.Constructor<?> cacheEntryConstructor = cacheEntryClass.getDeclaredConstructor(Rail.class, long.class, preparedRailClass);
+		cacheEntryConstructor.setAccessible(true);
+		final Object visibleEntry = cacheEntryConstructor.newInstance(null, 1L, visiblePreparedRail);
+		final Object offscreenEntry = cacheEntryConstructor.newInstance(null, 2L, offscreenPreparedRail);
+		final Method hasMissingVisiblePages = cacheEntryClass.getDeclaredMethod("hasMissingVisiblePages");
+		hasMissingVisiblePages.setAccessible(true);
+		final Method hasMissingPages = cacheEntryClass.getDeclaredMethod("hasMissingPages");
+		hasMissingPages.setAccessible(true);
+
+		Assertions.assertTrue(invokeInstanceBoolean(hasMissingVisiblePages, visibleEntry), "a visible null page must block the cached path until upload");
+		Assertions.assertTrue(invokeInstanceBoolean(hasMissingPages, visibleEntry), "a visible null page must be available to foreground or background upload");
+		Assertions.assertFalse(invokeInstanceBoolean(hasMissingVisiblePages, offscreenEntry), "an offscreen null page must not block already visible cached pages");
+		Assertions.assertTrue(invokeInstanceBoolean(hasMissingPages, offscreenEntry), "an offscreen null page must still be discovered by proactive background upload");
+
+		final java.lang.reflect.Constructor<?> uploadedPageConstructor = uploadedPageClass.getDeclaredConstructor(preparedPageClass, Mesh.class, OptimizedModel.class);
+		uploadedPageConstructor.setAccessible(true);
+		final Object uploadedPage = uploadedPageConstructor.newInstance(visiblePage, null, null);
+		final Field pagesField = cacheEntryClass.getDeclaredField("pages");
+		pagesField.setAccessible(true);
+		((ObjectArrayList<Object>) pagesField.get(visibleEntry)).set(0, uploadedPage);
+		Assertions.assertFalse(invokeInstanceBoolean(hasMissingVisiblePages, visibleEntry), "a filled visible page must no longer be reported missing");
+		Assertions.assertFalse(invokeInstanceBoolean(hasMissingPages, visibleEntry), "a fully filled entry must not be selected for background upload");
+	}
+
+	@Test
+	public void identicalGeometryAndUvsRemainDistinctAcrossLightValues() {
+		final Method appendSegmentVertices = requirePackageApi(
+				"appendSegmentVertices",
+				Consumer.class,
+				double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class, double.class, double.class,
+				double.class, double.class,
+				float.class, int.class
+		);
+		final List<Vertex> first = new ArrayList<>();
+		final List<Vertex> second = new ArrayList<>();
+		invoke(appendSegmentVertices, (Consumer<Vertex>) first::add, 0D, 0D, 0D, -1D, 0D, 1D, 0D, 1D, 0.5D, -1D, 0.5D, 0D, 0D, 0.065625F, 0x00F000A0);
+		invoke(appendSegmentVertices, (Consumer<Vertex>) second::add, 0D, 0D, 0D, -1D, 0D, 1D, 0D, 1D, 0.5D, -1D, 0.5D, 0D, 0D, 0.065625F, 0x00A000F0);
+
+		Assertions.assertEquals(8, first.size());
+		Assertions.assertEquals(first.size(), second.size());
+		for (int i = 0; i < first.size(); i++) {
+			final Vertex firstVertex = first.get(i);
+			final Vertex secondVertex = second.get(i);
+			Assertions.assertAll(
+					() -> Assertions.assertEquals(firstVertex.position, secondVertex.position, "geometry must be identical"),
+					() -> Assertions.assertEquals(firstVertex.u, secondVertex.u, "U must be identical"),
+					() -> Assertions.assertEquals(firstVertex.v, secondVertex.v, "V must be identical"),
+					() -> Assertions.assertNotEquals(firstVertex.light, secondVertex.light, "the fixture must use distinct packed light"),
+					() -> Assertions.assertNotEquals(firstVertex, secondVertex, "RawMesh.distinct must not merge differently lit vertices"),
+					() -> Assertions.assertEquals(1, firstVertex.normal.getY(), 0),
+					() -> Assertions.assertEquals(1, secondVertex.normal.getY(), 0),
+					() -> Assertions.assertTrue(Math.abs(firstVertex.normal.getX()) < Float.MIN_NORMAL && Math.abs(firstVertex.normal.getZ()) < Float.MIN_NORMAL, "encoded normal must remain visually equivalent to UP"),
+					() -> Assertions.assertTrue(Math.abs(secondVertex.normal.getX()) < Float.MIN_NORMAL && Math.abs(secondVertex.normal.getZ()) < Float.MIN_NORMAL, "encoded normal must remain visually equivalent to UP")
+			);
+		}
+	}
+
+	private static Class<?> requireCacheClass() {
+		try {
+			return Class.forName(CACHE_CLASS_NAME);
+		} catch (ClassNotFoundException exception) {
+			return Assertions.fail("Missing default rail mesh cache class: " + CACHE_CLASS_NAME, exception);
+		}
+	}
+
+	private static Class<?> requireNestedClass(String simpleName) {
+		return Arrays.stream(requireCacheClass().getDeclaredClasses())
+				.filter(candidate -> candidate.getSimpleName().equals(simpleName))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Missing nested cache class: " + simpleName));
+	}
+
+	private static Method requirePackageApi(String name, Class<?>... parameterTypes) {
+		final Method method;
+		try {
+			method = requireCacheClass().getDeclaredMethod(name, parameterTypes);
+		} catch (NoSuchMethodException exception) {
+			return Assertions.fail("Missing default rail mesh cache API: " + name + Arrays.toString(parameterTypes), exception);
+		}
+		Assertions.assertTrue(Modifier.isStatic(method.getModifiers()), name + " must be static");
+		Assertions.assertFalse(Modifier.isPrivate(method.getModifiers()), name + " must be package-visible or public");
+		method.setAccessible(true);
+		return method;
+	}
+
+	private static Number requireNumericConstant(String name) {
+		final Field field;
+		try {
+			field = requireCacheClass().getDeclaredField(name);
+			field.setAccessible(true);
+			final Object value = field.get(null);
+			if (value instanceof Number) {
+				return (Number) value;
+			}
+			return Assertions.fail(name + " must be numeric");
+		} catch (NoSuchFieldException | IllegalAccessException exception) {
+			return Assertions.fail("Missing default rail mesh cache constant: " + name, exception);
+		}
+	}
+
+	private static Object requireStaticField(String name) {
+		try {
+			final Field field = requireCacheClass().getDeclaredField(name);
+			field.setAccessible(true);
+			return field.get(null);
+		} catch (NoSuchFieldException | IllegalAccessException exception) {
+			return Assertions.fail("Missing default rail mesh cache field: " + name, exception);
+		}
+	}
+
+	private static void setStaticDouble(String name, double value) throws ReflectiveOperationException {
+		final Field field = requireCacheClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.setDouble(null, value);
+	}
+
+	private static void setStaticFloat(String name, float value) throws ReflectiveOperationException {
+		final Field field = requireCacheClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.setFloat(null, value);
+	}
+
+	private static double requireDoubleField(Object instance, String name) {
+		try {
+			final Field field = instance.getClass().getDeclaredField(name);
+			field.setAccessible(true);
+			return field.getDouble(instance);
+		} catch (NoSuchFieldException | IllegalAccessException exception) {
+			return Assertions.fail("Missing double field: " + name, exception);
+		}
+	}
+
+	private static void assertNonDegenerateDoubleSidedQuad(List<Vertex> vertices, float v1, float v2, int light) {
+		Assertions.assertEquals(8, vertices.size());
+		assertVertex(vertices.get(0), 1, 1.065625F, 0, 0, v2, light);
+		assertVertex(vertices.get(1), 3, 1.065625F + IGui.SMALL_OFFSET, 0, 1, v2, light);
+		assertVertex(vertices.get(2), 3, 2.065625F, 4, 1, v1, light);
+		assertVertex(vertices.get(3), 1, 2.065625F + IGui.SMALL_OFFSET, 4, 0, v1, light);
+		assertVertex(vertices.get(4), 3, 1.065625F + IGui.SMALL_OFFSET, 0, 0, v2, light);
+		assertVertex(vertices.get(5), 1, 1.065625F, 0, 1, v2, light);
+		assertVertex(vertices.get(6), 1, 2.065625F + IGui.SMALL_OFFSET, 4, 1, v1, light);
+		assertVertex(vertices.get(7), 3, 2.065625F, 4, 0, v1, light);
+
+		final float firstWinding = windingY(vertices.get(0), vertices.get(1), vertices.get(2));
+		final float secondWinding = windingY(vertices.get(4), vertices.get(5), vertices.get(6));
+		Assertions.assertNotEquals(0, firstWinding, "the golden quad must have non-zero area");
+		Assertions.assertEquals(-Math.signum(firstWinding), Math.signum(secondWinding), "the back face must reverse the front-face winding");
+	}
+
+	private static void assertPageLocalPrecision(Method appendSegmentVertices, double worldOrigin) {
+		final List<Vertex> vertices = new ArrayList<>();
+		invoke(
+				appendSegmentVertices,
+				(Consumer<Vertex>) vertices::add,
+				worldOrigin, 64D, worldOrigin,
+				worldOrigin + 0.125D, worldOrigin + 0.25D,
+				worldOrigin + 1.875D, worldOrigin + 0.25D,
+				worldOrigin + 1.875D, worldOrigin + 4.75D,
+				worldOrigin + 0.125D, worldOrigin + 4.75D,
+				64.375D, 64.875D,
+				0.065625F, 0x00F000A0
+		);
+
+		Assertions.assertEquals(8, vertices.size());
+		assertPosition(vertices.get(0), 0.125F, 0.440625F, 0.25F);
+		assertPosition(vertices.get(1), 1.875F, 0.440625F + IGui.SMALL_OFFSET, 0.25F);
+		assertPosition(vertices.get(2), 1.875F, 0.940625F, 4.75F);
+		assertPosition(vertices.get(3), 0.125F, 0.940625F + IGui.SMALL_OFFSET, 4.75F);
+		assertPosition(vertices.get(4), 1.875F, 0.440625F + IGui.SMALL_OFFSET, 0.25F);
+		assertPosition(vertices.get(5), 0.125F, 0.440625F, 0.25F);
+		assertPosition(vertices.get(6), 0.125F, 0.940625F + IGui.SMALL_OFFSET, 4.75F);
+		assertPosition(vertices.get(7), 1.875F, 0.940625F, 4.75F);
+	}
+
+	private static void assertPosition(Vertex vertex, float x, float y, float z) {
+		Assertions.assertAll(
+				() -> Assertions.assertEquals(x, vertex.position.getX(), 0.00001F),
+				() -> Assertions.assertEquals(y, vertex.position.getY(), 0.00001F),
+				() -> Assertions.assertEquals(z, vertex.position.getZ(), 0.00001F)
+		);
+	}
+
+	private static float windingY(Vertex first, Vertex second, Vertex third) {
+		final float firstX = second.position.getX() - first.position.getX();
+		final float firstZ = second.position.getZ() - first.position.getZ();
+		final float secondX = third.position.getX() - first.position.getX();
+		final float secondZ = third.position.getZ() - first.position.getZ();
+		return firstZ * secondX - firstX * secondZ;
+	}
+
+	private static boolean intersects(
+			double minX, double minY, double minZ, double maxX, double maxY, double maxZ,
+			double otherMinX, double otherMinY, double otherMinZ, double otherMaxX, double otherMaxY, double otherMaxZ
+	) {
+		return minX <= otherMaxX && maxX >= otherMinX && minY <= otherMaxY && maxY >= otherMinY && minZ <= otherMaxZ && maxZ >= otherMinZ;
+	}
+
+	private static void assertVertex(Vertex vertex, float x, float y, float z, float u, float v, int light) {
+		Assertions.assertAll(
+				() -> Assertions.assertEquals(x, vertex.position.getX(), 0.00001F),
+				() -> Assertions.assertEquals(y, vertex.position.getY(), 0.00001F),
+				() -> Assertions.assertEquals(z, vertex.position.getZ(), 0.00001F),
+				() -> Assertions.assertEquals(0, vertex.normal.getX(), 0.00001F),
+				() -> Assertions.assertEquals(1, vertex.normal.getY(), 0.00001F),
+				() -> Assertions.assertEquals(0, vertex.normal.getZ(), 0.00001F),
+				() -> Assertions.assertEquals(u, vertex.u, 0.00001F),
+				() -> Assertions.assertEquals(v, vertex.v, 0.00001F),
+				() -> Assertions.assertEquals(light, vertex.light)
+		);
+	}
+
+	private static boolean invokeBoolean(Method method, Object... arguments) {
+		final Object value = invoke(method, arguments);
+		return value instanceof Boolean ? (Boolean) value : Assertions.fail(method.getName() + " must return boolean");
+	}
+
+	private static boolean invokeInstanceBoolean(Method method, Object instance, Object... arguments) {
+		try {
+			final Object value = method.invoke(instance, arguments);
+			return value instanceof Boolean ? (Boolean) value : Assertions.fail(method.getName() + " must return boolean");
+		} catch (IllegalAccessException | InvocationTargetException exception) {
+			return Assertions.fail("Default rail mesh cache instance API failed: " + method.getName(), exception);
+		}
+	}
+
+	private static int invokeInt(Method method, Object... arguments) {
+		final Object value = invoke(method, arguments);
+		return value instanceof Number ? ((Number) value).intValue() : Assertions.fail(method.getName() + " must return an integer");
+	}
+
+	private static long invokeLong(Method method, Object... arguments) {
+		final Object value = invoke(method, arguments);
+		return value instanceof Number ? ((Number) value).longValue() : Assertions.fail(method.getName() + " must return a long");
+	}
+
+	private static Object invoke(Method method, Object... arguments) {
+		try {
+			return method.invoke(null, arguments);
+		} catch (IllegalAccessException | InvocationTargetException exception) {
+			return Assertions.fail("Default rail mesh cache API failed: " + method.getName(), exception);
+		}
+	}
+}

--- a/fabric/src/test/java/org/mtr/mod/render/JcmRenderRailsCompatibilityTest.java
+++ b/fabric/src/test/java/org/mtr/mod/render/JcmRenderRailsCompatibilityTest.java
@@ -1,0 +1,89 @@
+package org.mtr.mod.render;
+
+import com.logisticscraft.occlusionculling.OcclusionCullingInstance;
+import com.logisticscraft.occlusionculling.util.Vec3d;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mtr.core.data.Rail;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
+import org.mtr.mapping.holder.BlockPos;
+import org.mtr.mapping.holder.ClientWorld;
+import org.mtr.mapping.holder.Vector3d;
+import org.mtr.mapping.mapper.GraphicsHolder;
+import org.mtr.mod.client.MinecraftClientData;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+public final class JcmRenderRailsCompatibilityTest {
+
+	@Test
+	public void preservesOcclusionTaskInjectionDescriptor() {
+		assertDescriptor(
+				"lambda$render$1",
+				Runnable.class,
+				MinecraftClientData.RailWrapper.class,
+				Vec3d.class,
+				OcclusionCullingInstance.class
+		);
+	}
+
+	@Test
+	public void preservesRailCancellationInjectionDescriptor() {
+		assertDescriptor(
+				"lambda$render$5",
+				void.class,
+				boolean.class,
+				ObjectArraySet.class,
+				ClientWorld.class,
+				Rail.class
+		);
+	}
+
+	@Test
+	public void preservesRailStatsInjectionDescriptor() {
+		assertDescriptor(
+				"lambda$renderRailStats$24",
+				void.class,
+				BlockPos.class,
+				double.class,
+				BlockPos.class,
+				String.class,
+				String.class,
+				String.class,
+				String.class,
+				String.class,
+				String.class,
+				GraphicsHolder.class,
+				Vector3d.class
+		);
+	}
+
+	@Test
+	public void preservesStrictRenderLocalCapturePrefix() throws Exception {
+		Path renderRailsPath = Path.of("src", "main", "java", "org", "mtr", "mod", "render", "RenderRails.java");
+		if (!Files.exists(renderRailsPath)) {
+			renderRailsPath = Path.of("fabric").resolve(renderRailsPath);
+		}
+		Assertions.assertTrue(Files.exists(renderRailsPath), "RenderRails source must be available for JCM local capture verification");
+		final String source = Files.readString(renderRailsPath);
+		final int holdingRailRelatedIndex = source.indexOf("final boolean holdingRailRelated = isHoldingRailRelated(clientPlayerEntity);");
+		final int railsToRenderIndex = source.indexOf("final ObjectArrayList<Rail> railsToRender = new ObjectArrayList<>();", holdingRailRelatedIndex);
+		Assertions.assertTrue(holdingRailRelatedIndex >= 0 && railsToRenderIndex > holdingRailRelatedIndex, "JCM expects railsToRender immediately after holdingRailRelated in the render local table");
+		Assertions.assertFalse(source.substring(holdingRailRelatedIndex, railsToRenderIndex).contains("optimizedRailRendering"), "extra render locals break JCM's CAPTURE_FAILSOFT injection");
+		Assertions.assertFalse(source.contains("shouldBypassOcclusionCulling"), "batched rails must retain JCM visibility selection");
+		Assertions.assertTrue(source.contains("cullingTasks.add(occlusionCullingInstance ->"), "the original JCM culling lambda must remain present");
+	}
+
+	private static void assertDescriptor(String methodName, Class<?> returnType, Class<?>... parameterTypes) {
+		final Method method = Arrays.stream(RenderRails.class.getDeclaredMethods())
+				.filter(candidate -> candidate.getName().equals(methodName))
+				.findFirst()
+				.orElse(null);
+		Assertions.assertNotNull(method, "JCM injection target is missing: " + methodName);
+		Assertions.assertArrayEquals(parameterTypes, method.getParameterTypes(), "JCM injection descriptor changed: " + methodName);
+		Assertions.assertEquals(returnType, method.getReturnType(), "JCM injection return type changed: " + methodName);
+	}
+}

--- a/fabric/src/test/java/org/mtr/mod/render/RenderAPGGlassTest.java
+++ b/fabric/src/test/java/org/mtr/mod/render/RenderAPGGlassTest.java
@@ -1,0 +1,17 @@
+package org.mtr.mod.render;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mtr.mod.block.IBlock.DoubleBlockHalf;
+import org.mtr.mod.block.IBlock.EnumSide;
+
+public final class RenderAPGGlassTest {
+
+	@Test
+	public void onlyExtendedUpperHalvesProduceRouteRendering() {
+		Assertions.assertTrue(RenderAPGGlass.shouldRenderState(DoubleBlockHalf.UPPER, EnumSide.LEFT));
+		Assertions.assertTrue(RenderAPGGlass.shouldRenderState(DoubleBlockHalf.UPPER, EnumSide.MIDDLE));
+		Assertions.assertFalse(RenderAPGGlass.shouldRenderState(DoubleBlockHalf.UPPER, EnumSide.SINGLE));
+		Assertions.assertFalse(RenderAPGGlass.shouldRenderState(DoubleBlockHalf.LOWER, EnumSide.LEFT));
+	}
+}

--- a/fabric/src/test/java/org/mtr/mod/render/RenderRailVisibilityTest.java
+++ b/fabric/src/test/java/org/mtr/mod/render/RenderRailVisibilityTest.java
@@ -1,0 +1,145 @@
+package org.mtr.mod.render;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.util.Random;
+
+public final class RenderRailVisibilityTest {
+
+	private static final float[] SINE_TABLE = new float[65536];
+
+	static {
+		for (int i = 0; i < SINE_TABLE.length; i++) {
+			SINE_TABLE[i] = (float) Math.sin(i * Math.PI * 2 / SINE_TABLE.length);
+		}
+	}
+
+	@Test
+	public void testDistanceBoundaries() {
+		final double[] renderDistances = {16, 32, 224, 512};
+		for (final double renderDistance : renderDistances) {
+			assertEquivalent(renderDistance, 0, 0, 0, 0, 0, renderDistance, 0, 0);
+			assertEquivalent(Math.nextDown(renderDistance), 0, 0, 0, 0, 0, renderDistance, 0, 0);
+			assertEquivalent(Math.nextUp(renderDistance), 0, 0, 0, 0, 0, renderDistance, 0, 0);
+			assertEquivalent(-renderDistance, 0, 0, 0, 0, 0, renderDistance, 180, 0);
+			assertEquivalent(Math.nextUp(-renderDistance), 0, 0, 0, 0, 0, renderDistance, 180, 0);
+			assertEquivalent(Math.nextDown(-renderDistance), 0, 0, 0, 0, 0, renderDistance, 180, 0);
+		}
+
+		final double[] nearDistances = {Math.nextDown(32), 32, Math.nextUp(32)};
+		for (final double distance : nearDistances) {
+			assertEquivalent(distance, 0, 0, 0, 0, 0, 224, 0, 0);
+			assertEquivalent(0, 0, distance, 0, 0, 0, 224, 90, 0);
+		}
+
+		final Random random = new Random(0x424F554E44415259L);
+		for (int i = 0; i < 100000; i++) {
+			final boolean nearBoundary = random.nextBoolean();
+			final double renderDistance = nearBoundary ? 224 : 16 * (2 + random.nextInt(31));
+			final double threshold = nearBoundary ? 32 : renderDistance;
+			final double angle = random.nextDouble() * Math.PI * 2;
+			double distance = threshold;
+			final int adjacentSteps = random.nextInt(17) - 8;
+			for (int step = 0; step < Math.abs(adjacentSteps); step++) {
+				distance = Math.nextAfter(distance, adjacentSteps < 0 ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
+			}
+			assertEquivalent(Math.cos(angle) * distance, 0, Math.sin(angle) * distance, 0, 0, 0, renderDistance, 0, 0);
+		}
+	}
+
+	@Test
+	public void testFacingBoundaries() {
+		assertEquivalent(64, 0, Math.nextDown(0D), 0, 0, 0, 224, 0, 0);
+		assertEquivalent(64, 0, 0, 0, 0, 0, 224, 0, 0);
+		assertEquivalent(64, 0, Math.nextUp(0D), 0, 0, 0, 224, 0, 0);
+		assertEquivalent(64, Math.nextDown(0D), 0, 0, 0, 0, 224, 0, 90);
+		assertEquivalent(64, 0, 0, 0, 0, 0, 224, 0, 90);
+		assertEquivalent(64, Math.nextUp(0D), 0, 0, 0, 0, 224, 0, 90);
+
+		final float[] yaws = {-1080, -360, -180, -90, -45, 0, 45, 90, 180, 360, 1080};
+		final float[] pitches = {-90, -89.999F, -45, 0, 45, 89.999F, 90};
+		for (final float yaw : yaws) {
+			for (final float pitch : pitches) {
+				assertEquivalent(64, 0, 0, 0, 0, 0, 224, yaw, pitch);
+				assertEquivalent(0, 0, 64, 0, 0, 0, 224, yaw, pitch);
+				assertEquivalent(-64, 0, 0, 0, 0, 0, 224, yaw, pitch);
+				assertEquivalent(0, 0, -64, 0, 0, 0, 224, yaw, pitch);
+				assertEquivalent(64, Math.nextDown(0D), 0, 0, 0, 0, 224, yaw, pitch);
+				assertEquivalent(64, Math.nextUp(0D), 0, 0, 0, 0, 224, yaw, pitch);
+			}
+		}
+	}
+
+	@Test
+	public void testCoordinatesAndRandomizedInputs() {
+		assertEquivalent(-1000000, 255, 1000000, -1000064, -64, 1000000, 224, 0, 0);
+		assertEquivalent(30000000, -2048, -30000000, 29999800, 4096, -30000000, 512, 180, -89.999F);
+		assertEquivalent(-30000000, 4096, 30000000, -29999800, -2048, 30000000, 512, -180, 89.999F);
+
+		final Random random = new Random(0x4D54525241494CL);
+		for (int i = 0; i < 100000; i++) {
+			final double cameraX = randomCoordinate(random);
+			final double cameraY = randomCoordinate(random) / 64;
+			final double cameraZ = randomCoordinate(random);
+			final double x = cameraX + randomOffset(random);
+			final double y = cameraY + randomOffset(random);
+			final double z = cameraZ + randomOffset(random);
+			final double renderDistance = 16 * (2 + random.nextInt(31));
+			final float yaw = -1080 + random.nextFloat() * 2160;
+			final float pitch = -90 + random.nextFloat() * 180;
+			assertEquivalent(x, y, z, cameraX, cameraY, cameraZ, renderDistance, yaw, pitch);
+		}
+	}
+
+	private static double randomCoordinate(Random random) {
+		return (random.nextDouble() - 0.5) * 60000000;
+	}
+
+	private static double randomOffset(Random random) {
+		return (random.nextDouble() - 0.5) * 2048;
+	}
+
+	private static void assertEquivalent(double x, double y, double z, double cameraX, double cameraY, double cameraZ, double renderDistance, float yawDegrees, float pitchDegrees) {
+		final float yaw = (float) Math.toRadians(yawDegrees);
+		final float pitch = (float) Math.toRadians(pitchDegrees);
+		final float yawCos = minecraftCos(yaw);
+		final float yawSin = minecraftSin(yaw);
+		final float pitchCos = minecraftCos(pitch);
+		final float pitchSin = minecraftSin(pitch);
+		final boolean actual = RailVisibility.shouldRender(
+				x, y, z,
+				cameraX, cameraY, cameraZ,
+				renderDistance, renderDistance * renderDistance,
+				yawCos, yawSin,
+				pitchCos, pitchSin
+		);
+		final boolean expected = legacyShouldRender(x, y, z, cameraX, cameraY, cameraZ, renderDistance, yaw, pitch);
+		Assertions.assertEquals(expected, actual, () -> String.format(
+				"x=%s y=%s z=%s camera=(%s,%s,%s) renderDistance=%s yaw=%s pitch=%s",
+				x, y, z, cameraX, cameraY, cameraZ, renderDistance, yawDegrees, pitchDegrees
+		));
+	}
+
+	private static boolean legacyShouldRender(double x, double y, double z, double cameraX, double cameraY, double cameraZ, double renderDistance, float yaw, float pitch) {
+		final double differenceX = x - cameraX;
+		final double differenceY = y - cameraY;
+		final double differenceZ = z - cameraZ;
+		final double distanceToCamera = Math.sqrt(differenceX * differenceX + differenceZ * differenceZ);
+		if (distanceToCamera <= renderDistance) {
+			if (distanceToCamera < 32) {
+				return true;
+			}
+			final double yawRotatedZ = differenceZ * minecraftCos(yaw) - differenceX * minecraftSin(yaw);
+			return yawRotatedZ * minecraftCos(pitch) - differenceY * minecraftSin(pitch) > 0;
+		}
+		return false;
+	}
+
+	private static float minecraftSin(float value) {
+		return SINE_TABLE[(int) (value * 10430.378F) & 65535];
+	}
+
+	private static float minecraftCos(float value) {
+		return SINE_TABLE[(int) (value * 10430.378F + 16384) & 65535];
+	}
+}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -3,7 +3,7 @@ import org.mtr.mod.BuildTools
 
 plugins {
 	id "net.minecraftforge.gradle" version "6.0.54"
-	id "org.spongepowered.mixin" version "+"
+	id "org.spongepowered.mixin" version "0.7.38"
 }
 
 final BuildTools buildTools = new BuildTools(minecraftVersion, "forge", project)

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import org.mtr.mod.BuildTools
 
 plugins {
-	id "net.minecraftforge.gradle" version "6.+"
+	id "net.minecraftforge.gradle" version "6.0.54"
 	id "org.spongepowered.mixin" version "+"
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -70,6 +70,7 @@ tasks.register("setupFiles") {
 		outputs.upToDateWhen { false }
 		from "../fabric/src/main/java/org/mtr/mod"
 		into "src/main/java/org/mtr/mod"
+		exclude "mixin/ClientChunkLightUpdateMixin.java"
 	}
 
 	copy {

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-	id "org.gradle.toolchains.foojay-resolver-convention" version "+"
+	id "org.gradle.toolchains.foojay-resolver-convention" version "1.0.0"
 }
 
 include("fabric")


### PR DESCRIPTION
## Summary

- Cache eligible normal, default-style, 2D TRAIN rails as reusable static GPU meshes.
- Prepare rail geometry on up to two daemon workers, then upload pages incrementally on the render thread.
- Keep JCM rail-level occlusion selection, page visibility checks, light/resource/world invalidation, and legacy fallback.
- Retain the preceding render-allocation, dynamic-texture lifecycle, route-panel, renderer-state, and packet-serialization reductions.

## Controlled D3 result

A local copy of the production `world2` overworld was tested with a coordinate-validated 4,450 ms flight along D3 at Shuyuan North. Four accepted runs were collected for each build using the same client profile and route.

| Metric | Previous hotfix | GPU-mesh hotfix | Change |
| --- | ---: | ---: | ---: |
| Whole route mean FPS | 27.66 | 32.62 | **+17.9%** |
| North third mean FPS | 25.07 | 31.28 | **+24.8%** |
| Middle third mean FPS | 27.43 | 31.45 | **+14.7%** |
| South third mean FPS | 30.46 | 35.14 | **+15.4%** |
| Mean p95 frame time | 44.46 ms | 43.53 ms | **-2.1%** |

This is an incremental comparison against the preceding CPU-reduction hotfix, not an unmodified-upstream comparison.

Matched JFR render-thread samples changed as follows:

- `RenderRails`: 34.41% to 2.70% (-92.2%).
- Legacy `renderRailStandard`: 33.33% to 0.60% (-98.2%).
- `BufferBuilder.nextElement`: 16.13% to 0.30% (-98.1%).
- Sampled rail-rendering allocation volume: 435.9 MiB to 6.0 MiB (-98.6%).

## Mechanism

Eligible rails retain the existing 0.5 m tessellation but are split into 128-segment pages (nominally 64 m). CPU geometry preparation runs asynchronously. OpenGL upload remains render-thread-bound and is limited to eight pages per frame with a soft approximately 2 ms budget after the first upload. Uploaded VBO/IBO-backed meshes are then reused rather than rebuilt every frame. The cache uses page-local coordinates, retains per-segment light, has an estimated 128 MiB budget, and falls back to the legacy path until a page is ready or when a rail is ineligible.

This does not implement multithreaded OpenGL and does not use NVIDIA-specific APIs.

## Validation

- Fabric 1.20.1 clean build: successful.
- Fabric tests: 38 passed, 0 failed.
- GitHub Actions `build (1.20.1)`: successful, including normal and server builds.
- Matrix builds for 1.17.1, 1.18.2, 1.19.2, 1.19.4, 1.20.1, and 1.20.4: successful.
- 1.16.5 is not supported by this hotfix because its mappings do not provide the optimized render mesh APIs used by the cache.
- Exact tested/rebuilt Fabric jar SHA-256: `8B80F1A451F9DF6D5D892CDDB5B32C641098E4989B83A906FC2236A62DF470A0`.

Full methodology, compatibility scope, implementation details, and known limits are in `PERFORMANCE_HOTFIX.md`.