### PR TITLE
Add queue status indicator and counter to RailActionsScreen

### DIFF
--- a/fabric/src/main/java/org/mtr/mod/screen/RailActionsScreen.java
+++ b/fabric/src/main/java/org/mtr/mod/screen/RailActionsScreen.java
@@ -1,4 +1,4 @@
-package org.mtr.mod.screen;
+	package org.mtr.mod.screen;
 
 import org.mtr.mapping.mapper.GraphicsHolder;
 import org.mtr.mapping.mapper.ScreenExtension;
@@ -11,6 +11,8 @@ import org.mtr.mod.packet.PacketDeleteRailAction;
 public class RailActionsScreen extends MTRScreenBase implements IGui {
 
 	private final DashboardList railActionsList;
+	private int lastQueueSize = 0;
+	private int queueDisplayTicks = 0;
 
 	public RailActionsScreen(ScreenExtension previousScreenExtension) {
 		super(previousScreenExtension);
@@ -32,7 +34,16 @@ public class RailActionsScreen extends MTRScreenBase implements IGui {
 	public void render(GraphicsHolder graphicsHolder, int mouseX, int mouseY, float delta) {
 		renderBackground(graphicsHolder);
 		railActionsList.render(graphicsHolder);
+		
+		// Render main title
 		graphicsHolder.drawCenteredText(TranslationProvider.GUI_MTR_RAIL_ACTIONS.getMutableText(), width / 2, SQUARE_SIZE + TEXT_PADDING, ARGB_WHITE);
+		
+		// Render temporary queue status message if active
+		if (queueDisplayTicks > 0 && lastQueueSize > 0) {
+			String queueMessage = "Operations in queue: " + lastQueueSize;
+			graphicsHolder.drawCenteredText(queueMessage, width / 2, SQUARE_SIZE * 2 - 12, ARGB_YELLOW);
+		}
+		
 		super.render(graphicsHolder, mouseX, mouseY, delta);
 	}
 
@@ -51,6 +62,20 @@ public class RailActionsScreen extends MTRScreenBase implements IGui {
 	public void tick2() {
 		railActionsList.tick();
 		railActionsList.setData(MinecraftClientData.getInstance().railActions, false, false, false, false, false, true);
+
+		// Check queue size changes to trigger the temporary notice
+		int currentSize = MinecraftClientData.getInstance().railActions.size();
+		if (currentSize != lastQueueSize) {
+			lastQueueSize = currentSize;
+			if (currentSize > 0) {
+				queueDisplayTicks = 60; // Show notification for 3 seconds (60 ticks at 20 ticks/sec)
+			}
+		}
+
+		// Count down the display timer
+		if (queueDisplayTicks > 0) {
+			queueDisplayTicks--;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
This PR adds a real-time visual queue size indicator and display timer to the `RailActionsScreen`, improving user feedback during multiplayer operations.

## Details
- **Queue Counter**: Displays the current number of pending rail actions directly from `MinecraftClientData.getInstance().railActions.size()`.
- **Better UX**: Gives players instant visual confirmation when actions are queued or processing, preventing unnecessary repeated clicks in multiplayer environments.
- **Zero Overhead**: Leverages existing client-side synced data structures without requiring any new networking packets.
- 